### PR TITLE
fix(select): default font weight added

### DIFF
--- a/packages/ui-core/src/components/Select/Select.less
+++ b/packages/ui-core/src/components/Select/Select.less
@@ -3,8 +3,7 @@
 
 @{b} {
     .fontFamily();
-    .commonFont();
-    font-weight: 400;
+    .p();
     color: @freshAsphalt;
     min-height: 40px;
     position: relative;

--- a/packages/ui-core/src/components/Select/Select.less
+++ b/packages/ui-core/src/components/Select/Select.less
@@ -4,6 +4,7 @@
 @{b} {
     .fontFamily();
     .commonFont();
+    font-weight: 400;
     color: @freshAsphalt;
     min-height: 40px;
     position: relative;


### PR DESCRIPTION
fixes wrong font weight in select when parent element has its own font weight