### PR TITLE
fix(carousel): turn off swiping on pagination

### DIFF
--- a/packages/ui-core/src/components/Carousel/Carousel.tsx
+++ b/packages/ui-core/src/components/Carousel/Carousel.tsx
@@ -130,7 +130,7 @@ const Carousel: React.FC<ICarouselProps> = ({
     autoPlayDelay = 5000,
     loop = false,
     transitionSpeed = 300,
-    threshold = 1,
+    threshold,
     disableTouchMove = false,
     centeredSlides = false,
     navTheme = 'light',
@@ -256,7 +256,7 @@ const Carousel: React.FC<ICarouselProps> = ({
                 allowTouchMove={!disableTouchMove}
                 centeredSlides={centeredSlides}
                 effect={effectTheme}
-                noSwipingSelector={noSwipingSelector}
+                noSwipingSelector={!!noSwipingSelector ? `.swiper-pagination, ${noSwipingSelector}` : '.swiper-pagination'}
                 onSwiper={handleSwiper}
                 onReachBeginning={handleReachBeginnig}
                 onReachEnd={handleReachEnd}

--- a/packages/ui-core/src/components/Carousel/__snapshots__/Carousel.test.tsx.snap
+++ b/packages/ui-core/src/components/Carousel/__snapshots__/Carousel.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`<Carousel /> should render with default props 1`] = `
     className="mfui-beta-carousel__swiper mfui-beta-carousel__swiper_default-inner-indents"
     effect="slide"
     loop={false}
+    noSwipingSelector=".swiper-pagination"
     onFromEdge={[Function]}
     onReachBeginning={[Function]}
     onReachEnd={[Function]}
@@ -41,7 +42,6 @@ exports[`<Carousel /> should render with default props 1`] = `
       }
     }
     speed={300}
-    threshold={1}
     watchOverflow={true}
     watchSlidesVisibility={true}
   >
@@ -107,7 +107,7 @@ exports[`<Carousel /> should render with props 1`] = `
     containerModifierClass="containerModifier"
     effect="fade"
     loop={true}
-    noSwipingSelector="button"
+    noSwipingSelector=".swiper-pagination, button"
     onFromEdge={[Function]}
     onReachBeginning={[Function]}
     onReachEnd={[Function]}
@@ -122,7 +122,6 @@ exports[`<Carousel /> should render with props 1`] = `
       }
     }
     speed={1000}
-    threshold={1}
     watchOverflow={true}
     watchSlidesVisibility={true}
   >


### PR DESCRIPTION
По дефолту в параметр noSwipingSelector добавлен класс контейнера пагинации, чтобы отключить свайп при клике на точки пагинации и устранить баг с неверным переключением слайдов.
Также убрано дефолтное значение параметра threshold.