### PR TITLE
feat(downloadlinks): add props 'inOneColumn' for render links in one …

### DIFF
--- a/packages/ui-shared/src/components/DownloadLinks/DownloadLinks.less
+++ b/packages/ui-shared/src/components/DownloadLinks/DownloadLinks.less
@@ -36,4 +36,8 @@
             }
         }
     }
+
+    &__item:not(:first-child) {
+        margin-top: @gap;
+    }
 }

--- a/packages/ui-shared/src/components/DownloadLinks/DownloadLinks.test.tsx
+++ b/packages/ui-shared/src/components/DownloadLinks/DownloadLinks.test.tsx
@@ -43,4 +43,19 @@ describe('DownloadLinks', () => {
         );
         expect(wrapper).toMatchSnapshot();
     });
+
+    it('render component with one column regardless of the quantity', () => {
+        const wrapper = shallow(
+            <DownloadLinks inOneColumn>
+                <DownloadLink {...props} />
+                <DownloadLink {...props} />
+                <DownloadLink {...props} />
+                <DownloadLink {...props} />
+                <DownloadLink {...props} />
+                <DownloadLink {...props} />
+                <DownloadLink {...props} />
+            </DownloadLinks>,
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/packages/ui-shared/src/components/DownloadLinks/DownloadLinks.tsx
+++ b/packages/ui-shared/src/components/DownloadLinks/DownloadLinks.tsx
@@ -43,11 +43,23 @@ const getColumnConfig = (itemsCount): ColumnConfig => {
 };
 
 interface IDownloadLinks {
+    /** Выстраивать ссылки в одну колонку вне зависимости от количества */
+    inOneColumn?: boolean;
     children: Array<React.ReactElement<IDownloadLink>> | React.ReactElement<IDownloadLink>;
 }
 
 const cn = cnCreate('mfui-beta-download-links');
-const DownloadLinks: React.FC<IDownloadLinks> = ({ children }) => {
+const DownloadLinks: React.FC<IDownloadLinks> = ({ inOneColumn = false, children }) => {
+    if (inOneColumn) {
+        return (
+            <div className={cn()}>
+                {React.Children.map(children, child => (
+                    <div className={cn('item')}>{child}</div>
+                ))}
+            </div>
+        );
+    }
+
     const itemsCount = React.Children.count(children);
     const columnConfig = getColumnConfig(itemsCount);
 
@@ -65,6 +77,7 @@ const DownloadLinks: React.FC<IDownloadLinks> = ({ children }) => {
 };
 
 DownloadLinks.propTypes = {
+    inOneColumn: PropTypes.bool,
     children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.element.isRequired), PropTypes.element]).isRequired,
 };
 

--- a/packages/ui-shared/src/components/DownloadLinks/__snapshots__/DownloadLinks.test.tsx.snap
+++ b/packages/ui-shared/src/components/DownloadLinks/__snapshots__/DownloadLinks.test.tsx.snap
@@ -24,6 +24,90 @@ exports[`DownloadLinks render component with one column 1`] = `
 </div>
 `;
 
+exports[`DownloadLinks render component with one column regardless of the quantity 1`] = `
+<div
+  className="mfui-beta-download-links"
+>
+  <div
+    className="mfui-beta-download-links__item"
+    key=".0"
+  >
+    <DownloadLink
+      extension="PDF"
+      fileSize="500 MB"
+      href="href"
+      text="text"
+    />
+  </div>
+  <div
+    className="mfui-beta-download-links__item"
+    key=".1"
+  >
+    <DownloadLink
+      extension="PDF"
+      fileSize="500 MB"
+      href="href"
+      text="text"
+    />
+  </div>
+  <div
+    className="mfui-beta-download-links__item"
+    key=".2"
+  >
+    <DownloadLink
+      extension="PDF"
+      fileSize="500 MB"
+      href="href"
+      text="text"
+    />
+  </div>
+  <div
+    className="mfui-beta-download-links__item"
+    key=".3"
+  >
+    <DownloadLink
+      extension="PDF"
+      fileSize="500 MB"
+      href="href"
+      text="text"
+    />
+  </div>
+  <div
+    className="mfui-beta-download-links__item"
+    key=".4"
+  >
+    <DownloadLink
+      extension="PDF"
+      fileSize="500 MB"
+      href="href"
+      text="text"
+    />
+  </div>
+  <div
+    className="mfui-beta-download-links__item"
+    key=".5"
+  >
+    <DownloadLink
+      extension="PDF"
+      fileSize="500 MB"
+      href="href"
+      text="text"
+    />
+  </div>
+  <div
+    className="mfui-beta-download-links__item"
+    key=".6"
+  >
+    <DownloadLink
+      extension="PDF"
+      fileSize="500 MB"
+      href="href"
+      text="text"
+    />
+  </div>
+</div>
+`;
+
 exports[`DownloadLinks render component with three columns 1`] = `
 <div
   className="mfui-beta-download-links mfui-beta-download-links_count_5"

--- a/packages/ui-shared/src/components/DownloadLinks/doc/DownloadLinks.example.mdx
+++ b/packages/ui-shared/src/components/DownloadLinks/doc/DownloadLinks.example.mdx
@@ -66,3 +66,17 @@ const href = 'href';
         <DownloadLink href={href} text={text} extension={extension} fileSize={fileSize} />
     </DownloadLinks>
 </Playground>
+
+## Одна колонка вне зависимости от количества ссылок
+<Playground>
+    <DownloadLinks inOneColumn>
+        <DownloadLink href={href} text={text} extension={extension} fileSize={fileSize} />
+        <DownloadLink href={href} text={text} extension={extension} fileSize={fileSize} />
+        <DownloadLink href={href} text={text} extension={extension} fileSize={fileSize} />
+        <DownloadLink href={href} text={text} extension={extension} fileSize={fileSize} />
+        <DownloadLink href={href} text={text} extension={extension} fileSize={fileSize} />
+        <DownloadLink href={href} text={text} extension={extension} fileSize={fileSize} />
+        <DownloadLink href={href} text={text} extension={extension} fileSize={fileSize} />
+        <DownloadLink href={href} text={text} extension={extension} fileSize={fileSize} />
+    </DownloadLinks>
+</Playground>

--- a/packages/ui-shared/src/components/DownloadLinks/doc/DownloadLinks.mdx
+++ b/packages/ui-shared/src/components/DownloadLinks/doc/DownloadLinks.mdx
@@ -8,7 +8,7 @@ import Example from './DownloadLinks.example.mdx';
 import Props from './DownloadLinks.props.mdx';
 
 # DownloadLinks
-У данного компонента есть один пропс children в который должны передаваться только компоненты **DownloadLink**
+Пропсу children должны передаваться только компоненты **DownloadLink**
 
 <CopyToClipboardBox text="import { DownloadLinks, DownloadLink } from '@megafon/ui-shared';" />
 

--- a/packages/ui-shared/src/components/DownloadLinks/doc/DownloadLinks.props.mdx
+++ b/packages/ui-shared/src/components/DownloadLinks/doc/DownloadLinks.props.mdx
@@ -2,5 +2,8 @@ import { Props } from 'docz';
 import DownloadLinks from '../DownloadLinks';
 import DownloadLink from '../DownloadLink';
 
+## DownloadLinks
+<Props of={DownloadLinks} />
+
 ## DownloadLink
 <Props of={DownloadLink} />


### PR DESCRIPTION
…column, regardless of quantity