### PR TITLE
Hotfix

### DIFF
--- a/packages/ui-core/src/styles/colors.css
+++ b/packages/ui-core/src/styles/colors.css
@@ -1,7 +1,7 @@
 :root {
     /* Basic Colors */
     --brandGreen: #00B956;
-    --beandPurple: #731982;
+    --brandPurple: #731982;
     --base: #FFFFFF;
     --content: #333333;
     --spbSky0: #F6F6F6;

--- a/packages/ui-helpers/CHANGELOG.md
+++ b/packages/ui-helpers/CHANGELOG.md
@@ -19,13 +19,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **ui-helpers:** add a11y function to check event is click or enter press ([8ed8e5e](https://github.com/MegafonWebLab/megafon-ui/commit/8ed8e5ee9fc0be112d40337dbe1a3ac45cf57f6f))
 
 
-### BREAKING CHANGES
-
-* **colors:** green, green20, green80, purple, purple20 and purple80 colors now have 'brand'
-prefix (e.g. brandGreen)
-* **colors:** read commit description
-
-
 
 
 

--- a/packages/ui-icons/CHANGELOG.md
+++ b/packages/ui-icons/CHANGELOG.md
@@ -17,13 +17,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **colors:** css custom properties and color themes support ([16df5b7](https://github.com/MegafonWebLab/megafon-ui/commit/16df5b7b2644e15bb6c6e49e7347c0f8e4839e58))
 
 
-### BREAKING CHANGES
-
-* **colors:** green, green20, green80, purple, purple20 and purple80 colors now have 'brand'
-prefix (e.g. brandGreen)
-* **colors:** read commit description
-
-
 
 
 

--- a/packages/ui-shared/CHANGELOG.md
+++ b/packages/ui-shared/CHANGELOG.md
@@ -28,18 +28,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * **textwithicon:** prop items removed, list items are now added by child components
 * **accordionbox:** remove prop hasVerticalPaddings
-* ContentArea: prop color change values from 'base' to 'white' and from 'content' to 'default';
-remove depreacted value 'freshAsphalt'
-Paragraph: prop color change values from 'base' to 'white' and from 'contend' to 'default';
-remove deprecared values 'freshAsphalt' and 'clearWhite'
-StoreBanner: prop theme change value from 'black' to 'default'; remove deprecated value 'clearWhite'
-* ContentArea, Paragraph, StoreBanner and Breadcrumbs components from no don't have
-freshAsphalt and clearWhite as values for colorize props
 * **accordion-box:** remove parameter 'title' in onClickAccordion prop
 * **colors:** green, green20, green80, purple, purple20 and purple80 colors now have 'brand'
 prefix (e.g. brandGreen)
-* **colors:** read commit description
-
+* **contentarea**: prop color change values from 'base' to 'white' and from 'content' to 'default';
+remove depreacted value 'freshAsphalt'
+* **contentarea**, **paragraph**, **storebanner** and **breadcrumbs** components from no don't have
+'freshAsphalt' and 'clearWhite' as values for colorizing props
+* **storebanner**: prop theme change value from 'black' to 'default'; remove deprecated value 'clearWhite'
+* **components:** for the components to work correctly, now it's needed to import colors.css file
 
 
 


### PR DESCRIPTION
- `changelog`: fix ui-shared, ui-helpers and ui-icons changelogs
- `colors`: fix typo in color name in `colors.css`: `--beandPurple` to `--brandPurple`