### PR TITLE
fix(carousel): add resize listener to nav display

### DIFF
--- a/packages/ui-core/src/components/Carousel/Carousel.tsx
+++ b/packages/ui-core/src/components/Carousel/Carousel.tsx
@@ -237,12 +237,16 @@ const Carousel: React.FC<ICarouselProps> = ({
         }
     };
 
+    const handleNavDisplay = (swiper: SwiperCore) => {
+        setBeginning(swiper.isBeginning);
+        setEnd(swiper.isEnd);
+        setLocked(swiper.isBeginning && swiper.isEnd);
+    };
+
     // https://github.com/nolimits4web/Swiper/issues/2346
     const handleSwiperResize = React.useCallback(() => {
         throttle((swiper: SwiperCore) => {
-            setBeginning(swiper.isBeginning);
-            setEnd(swiper.isEnd);
-            setLocked(swiper.isBeginning && swiper.isEnd);
+            handleNavDisplay(swiper);
 
             if (swiper.params.slidesPerView === SlidesPerView.AUTO) {
                 swiper.slides.css('width', '');
@@ -270,6 +274,21 @@ const Carousel: React.FC<ICarouselProps> = ({
     const disableFocusOnSlideClick = (e: React.MouseEvent) => {
         e.nativeEvent.preventDefault();
     };
+
+    React.useEffect(() => {
+        if (!swiperInstance) {
+            return undefined;
+        }
+
+        const windowResizeHandler = () => handleNavDisplay(swiperInstance);
+        const windowResizeHandlerThrottled = throttle(windowResizeHandler, throttleTime.resize);
+
+        window.addEventListener('resize', windowResizeHandlerThrottled);
+
+        return () => {
+            window.removeEventListener('resize', windowResizeHandlerThrottled);
+        };
+    }, [swiperInstance]);
 
     return (
         <div


### PR DESCRIPTION
<!-- Autogenerated checksum:32bce9f62ae916e26f8e022e98c0415a71b3318e_12abd93d226676d2c4f78968c9d5de032783ec8d -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "3.0.2"
"version": "3.0.3"

ui-shared/package.json
"version": "3.0.3"
"version": "3.0.4"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
## [3.0.3](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@3.0.2...@megafon/ui-core@3.0.3) (2022-02-22)


### Bug Fixes

* **carousel:** add resize listener to nav display ([12abd93](https://github.com/MegafonWebLab/megafon-ui/commit/12abd93d226676d2c4f78968c9d5de032783ec8d))





## :memo: packages/ui-shared/CHANGELOG.md
## [3.0.4](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.0.3...@megafon/ui-shared@3.0.4) (2022-02-22)

**Note:** Version bump only for package @megafon/ui-shared





