### PR TITLE
Release 22.02.2022

### DIFF
--- a/packages/ui-core/CHANGELOG.md
+++ b/packages/ui-core/CHANGELOG.md
@@ -76,7 +76,7 @@ remove depreacted value 'freshAsphalt'
 * **contentarea**, **paragraph**, **storebanner** and **breadcrumbs** components from no don't have
 'freshAsphalt' and 'clearWhite' as values for colorizing props
 * **paragraph:** remove from color prop values: 'spbSky0', 'spbSky1', 'spbSky2'
-* **paragraph**: prop color change values from 'base' to 'white' and from 'contend' to 'default';
+* **paragraph**: prop color change values from 'base' to 'white' and from 'content' to 'default';
 remove deprecared values 'freshAsphalt' and 'clearWhite'
 * **storebanner**: prop theme change value from 'black' to 'default'; remove deprecated value 'clearWhite'
 * **tooltip:** change onOpen, onClose types; AccessibilityEventTypeNative from @megafon/ui-helpers

--- a/packages/ui-core/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/ui-core/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -68,9 +68,7 @@ exports[`<Accordion /> it render Accordion with controlled state 1`] = `
         className="mfui-accordion__content"
         style={
           Object {
-            "height": "auto",
             "overflow": "hidden",
-            "transition": "height 0.3s",
           }
         }
       >
@@ -153,9 +151,7 @@ exports[`<Accordion /> it renders Accordion 1`] = `
         className="mfui-accordion__content"
         style={
           Object {
-            "height": "0px",
             "overflow": "hidden",
-            "transition": "height 0.3s",
           }
         }
       >

--- a/packages/ui-core/src/components/Banner/Banner.less
+++ b/packages/ui-core/src/components/Banner/Banner.less
@@ -2,6 +2,7 @@
 
 @b: e('.mfui-banner');
 @sw: e('.swiper-wrapper');
+@swiperSlideVisible: e('.swiper-slide-visible');
 
 @{b} {
     position: relative;
@@ -19,11 +20,25 @@
         @media @mobileB {
             height: 540px;
         }
+        @media @desktop {
+            backface-visibility: hidden; // fix opacity transition bug in Safari 13
+            opacity: 0;
+
+            transition: opacity 0.2s;
+        }
         @media @desktopS {
             height: 420px;
         }
         @media @desktopMU {
             height: 400px;
+        }
+    }
+
+    @{swiperSlideVisible} {
+        @media @desktop {
+            opacity: 1;
+
+            transition: opacity 0.4s;
         }
     }
 

--- a/packages/ui-core/src/components/Banner/Banner.tsx
+++ b/packages/ui-core/src/components/Banner/Banner.tsx
@@ -200,14 +200,14 @@ const Banner: React.FC<IBannerProps> = ({
                 ))}
             </Swiper>
             <NavArrow
-                {...filterDataAttrs(dataAttrs?.arrowPrev)}
+                dataAttrs={{ root: dataAttrs?.arrowPrev }}
                 className={cn('arrow', { prev: true }, [classes.arrow])}
                 onClick={handlePrevClick}
                 disabled={!loop && isBeginning}
                 theme={navArrowTheme}
             />
             <NavArrow
-                {...filterDataAttrs(dataAttrs?.arrowNext)}
+                dataAttrs={{ root: dataAttrs?.arrowNext }}
                 className={cn('arrow', { next: true }, [classes.arrow])}
                 view="next"
                 onClick={handleNextClick}

--- a/packages/ui-core/src/components/Banner/Banner.tsx
+++ b/packages/ui-core/src/components/Banner/Banner.tsx
@@ -180,6 +180,7 @@ const Banner: React.FC<IBannerProps> = ({
                 className={cn('swiper')}
                 loop={loop}
                 autoplay={autoPlay ? getAutoPlayConfig(autoPlayDelay) : false}
+                watchSlidesVisibility
                 onSwiper={handleSwiper}
                 onReachBeginning={handleReachBeginning}
                 onReachEnd={handleReachEnd}

--- a/packages/ui-core/src/components/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/packages/ui-core/src/components/Banner/__snapshots__/Banner.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`<Banner /> should render with default props 1`] = `
     onSlideChange={[Function]}
     onSwiper={[Function]}
     onTouchEnd={[Function]}
+    watchSlidesVisibility={true}
   >
     <SwiperSlide
       className="mfui-banner__slide"
@@ -105,6 +106,7 @@ exports[`<Banner /> should render with props 1`] = `
     onSlideChange={[Function]}
     onSwiper={[Function]}
     onTouchEnd={[Function]}
+    watchSlidesVisibility={true}
   >
     <SwiperSlide
       className="mfui-banner__slide slide"

--- a/packages/ui-core/src/components/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/packages/ui-core/src/components/Banner/__snapshots__/Banner.test.tsx.snap
@@ -36,12 +36,22 @@ exports[`<Banner /> should render with default props 1`] = `
   </Swiper>
   <NavArrow
     className="mfui-banner__arrow mfui-banner__arrow_prev"
+    dataAttrs={
+      Object {
+        "root": undefined,
+      }
+    }
     disabled={true}
     onClick={[Function]}
     theme="purple"
   />
   <NavArrow
     className="mfui-banner__arrow mfui-banner__arrow_next"
+    dataAttrs={
+      Object {
+        "root": undefined,
+      }
+    }
     disabled={false}
     onClick={[Function]}
     theme="purple"
@@ -129,14 +139,26 @@ exports[`<Banner /> should render with props 1`] = `
   </Swiper>
   <NavArrow
     className="mfui-banner__arrow mfui-banner__arrow_prev arrows"
-    data-arrow-prev="test-id"
+    dataAttrs={
+      Object {
+        "root": Object {
+          "data-arrow-prev": "test-id",
+        },
+      }
+    }
     disabled={false}
     onClick={[Function]}
     theme="dark"
   />
   <NavArrow
     className="mfui-banner__arrow mfui-banner__arrow_next arrows"
-    data-arrow-next="test-id"
+    dataAttrs={
+      Object {
+        "root": Object {
+          "data-arrow-next": "test-id",
+        },
+      }
+    }
     disabled={false}
     onClick={[Function]}
     theme="dark"

--- a/packages/ui-core/src/components/Banner/doc/Banner.example.mdx
+++ b/packages/ui-core/src/components/Banner/doc/Banner.example.mdx
@@ -3,22 +3,20 @@ import Banner from '../Banner';
 import { DemoSlide, OffsetBlock } from './Banner.docz';
 
 ```javascript collapse=Код DemoSlide
-export const DemoSlide = ({ children, background }) => {
-    return (
-        <div
-            style={{
-                height: "100%",
-                backgroundColor: background,
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-                fontSize: '30px',
-            }}
-        >
-            {children}
-        </div>
-    );
-}
+export const DemoSlide = ({ children, background = '#fff' }) => (
+    <div
+        style={{
+            height: '100%',
+            backgroundColor: background,
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            fontSize: '30px',
+        }}
+    >
+        {children}
+    </div>
+);
 
 export const OffsetBlock = () => (
     <div

--- a/packages/ui-core/src/components/Button/Button.less
+++ b/packages/ui-core/src/components/Button/Button.less
@@ -239,15 +239,15 @@
     }
 
     &_no-touch&_type_outline&_theme_white {
-        --base7: rgba(255, 255, 255, 0.07);
-        --base14: rgba(255, 255, 255, 0.14);
+        --stcWhite7: rgba(255, 255, 255, 0.07);
+        --stcWhite14: rgba(255, 255, 255, 0.14);
 
         &:not(@{b}_loading):hover {
-            background-color: var(--base7);
+            background-color: var(--stcWhite7);
         }
 
         &:not(@{b}_loading):active {
-            background-color: var(--base14);
+            background-color: var(--stcWhite14);
         }
     }
 
@@ -266,15 +266,15 @@
     }
 
     &_no-touch&_type_outline&_theme_black {
-        --content7: rgba(51, 51, 51, 0.07);
-        --content14: rgba(51, 51, 51, 0.14);
+        --stcBlack7: rgba(51, 51, 51, 0.07);
+        --stcBlack14: rgba(51, 51, 51, 0.14);
 
         &:not(@{b}_loading):hover {
-            background-color: var(--content7);
+            background-color: var(--stcBlack7);
         }
 
         &:not(@{b}_loading):active {
-            background-color: var(--content14);
+            background-color: var(--stcBlack14);
         }
     }
 

--- a/packages/ui-core/src/components/Calendar/Calendar.test.tsx
+++ b/packages/ui-core/src/components/Calendar/Calendar.test.tsx
@@ -3,6 +3,13 @@ import { shallow, mount } from 'enzyme';
 import Calendar, { ICalendarProps } from './Calendar';
 
 const props: ICalendarProps = {
+    dataAttrs: {
+        root: { 'data-testid': 'root' },
+        day: { 'data-testid': 'day-test' },
+        month: { 'data-testid': 'month-test' },
+        arrowLeft: { 'data-testid': 'arrowLeft-test' },
+        arrowRight: { 'data-testid': 'arrowRight-test' },
+    },
     className: 'rootClass',
     startDate: new Date(2020, 1, 7),
     endDate: new Date(2020, 1, 14),

--- a/packages/ui-core/src/components/Calendar/Calendar.tsx
+++ b/packages/ui-core/src/components/Calendar/Calendar.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useState, useEffect, useMemo } from 'react';
 import { FocusedInput, START_DATE, END_DATE, useDatepicker, useMonth } from '@datepicker-react/hooks';
-import { cnCreate } from '@megafon/ui-helpers';
+import { cnCreate, filterDataAttrs } from '@megafon/ui-helpers';
 import differenceInDays from 'date-fns/differenceInDays';
 import format from 'date-fns/format';
 import isAfter from 'date-fns/isAfter';
@@ -28,6 +28,14 @@ interface ICalendarState {
 }
 
 export interface ICalendarProps {
+    /** Дополнительные data атрибуты к внутренним элементам */
+    dataAttrs?: {
+        root?: Record<string, string>;
+        day?: Record<string, string>;
+        month?: Record<string, string>;
+        arrowLeft?: Record<string, string>;
+        arrowRight?: Record<string, string>;
+    };
     /** Переключение календаря в режим выбора одной даты вместо периода */
     isSingleDate?: boolean;
     /** Классы для модификации компонента */
@@ -50,6 +58,7 @@ const monthLabelFormat = (date: Date): string => formatDate(date, 'LLLL');
 
 const cn = cnCreate('mfui-calendar');
 const Calendar: React.FC<ICalendarProps> = ({
+    dataAttrs,
     isSingleDate = false,
     startDate = null,
     endDate = null,
@@ -185,6 +194,9 @@ const Calendar: React.FC<ICalendarProps> = ({
 
                 return (
                     <Day
+                        dataAttrs={{
+                            root: { ...filterDataAttrs(dataAttrs?.day, index + 1) },
+                        }}
                         date={date}
                         key={formatDate(date, 'dd-MM-yyyy')}
                         dayLabel={dayLabel}
@@ -217,6 +229,11 @@ const Calendar: React.FC<ICalendarProps> = ({
 
             return (
                 <Month
+                    dataAttrs={{
+                        root: dataAttrs?.month,
+                        arrowLeft: dataAttrs?.arrowLeft,
+                        arrowRight: dataAttrs?.arrowRight,
+                    }}
                     key={`${year}-${month}`}
                     year={year}
                     weekdayLabels={weekdayLabels}
@@ -231,10 +248,21 @@ const Calendar: React.FC<ICalendarProps> = ({
             );
         });
 
-    return <div className={cn([className])}>{renderMonths()}</div>;
+    return (
+        <div {...filterDataAttrs(dataAttrs?.root)} className={cn([className])}>
+            {renderMonths()}
+        </div>
+    );
 };
 
 Calendar.propTypes = {
+    dataAttrs: PropTypes.shape({
+        root: PropTypes.objectOf(PropTypes.string.isRequired),
+        day: PropTypes.objectOf(PropTypes.string.isRequired),
+        month: PropTypes.objectOf(PropTypes.string.isRequired),
+        arrowLeft: PropTypes.objectOf(PropTypes.string.isRequired),
+        arrowRight: PropTypes.objectOf(PropTypes.string.isRequired),
+    }),
     isSingleDate: PropTypes.bool,
     className: PropTypes.string,
     startDate: PropTypes.instanceOf(Date),

--- a/packages/ui-core/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/ui-core/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
@@ -3,6 +3,25 @@
 exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
 <Calendar
   className="rootClass"
+  dataAttrs={
+    Object {
+      "arrowLeft": Object {
+        "data-testid": "arrowLeft-test",
+      },
+      "arrowRight": Object {
+        "data-testid": "arrowRight-test",
+      },
+      "day": Object {
+        "data-testid": "day-test",
+      },
+      "month": Object {
+        "data-testid": "month-test",
+      },
+      "root": Object {
+        "data-testid": "root",
+      },
+    }
+  }
   endDate={2020-02-14T00:00:00.000Z}
   isSingleDate={true}
   maxBookingDate={2020-02-25T00:00:00.000Z}
@@ -12,8 +31,22 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
 >
   <div
     className="mfui-calendar rootClass"
+    data-testid="root"
   >
     <Month
+      dataAttrs={
+        Object {
+          "arrowLeft": Object {
+            "data-testid": "arrowLeft-test",
+          },
+          "arrowRight": Object {
+            "data-testid": "arrowRight-test",
+          },
+          "root": Object {
+            "data-testid": "month-test",
+          },
+        }
+      }
       goToNextMonth={[Function]}
       goToPreviousMonth={[Function]}
       isNextMonthDisabled={true}
@@ -35,12 +68,14 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
     >
       <div
         className="mfui-month"
+        data-testid="month-test"
       >
         <div
           className="mfui-month__header"
         >
           <test-file-stub
             className="mfui-month__arrow mfui-month__arrow_disabled"
+            data-testid="arrowLeft-test"
             onClick={[Function]}
             onKeyDown={[Function]}
             role="button"
@@ -53,6 +88,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           </span>
           <test-file-stub
             className="mfui-month__arrow mfui-month__arrow_disabled"
+            data-testid="arrowRight-test"
             onClick={[Function]}
             onKeyDown={[Function]}
             role="button"
@@ -124,6 +160,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             key="4"
           />
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[6]",
+                },
+              }
+            }
             date={2020-02-01T00:00:00.000Z}
             dayLabel="1"
             focusedDate={null}
@@ -150,6 +193,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day mfui-day_disabled mfui-day_first"
+              data-testid="day-test[6]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -165,6 +209,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[7]",
+                },
+              }
+            }
             date={2020-02-02T00:00:00.000Z}
             dayLabel="2"
             focusedDate={null}
@@ -191,6 +242,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day mfui-day_disabled mfui-day_sunday"
+              data-testid="day-test[7]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -206,6 +258,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[8]",
+                },
+              }
+            }
             date={2020-02-03T00:00:00.000Z}
             dayLabel="3"
             focusedDate={null}
@@ -232,6 +291,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day mfui-day_monday"
+              data-testid="day-test[8]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -247,6 +307,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[9]",
+                },
+              }
+            }
             date={2020-02-04T00:00:00.000Z}
             dayLabel="4"
             focusedDate={null}
@@ -273,6 +340,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day"
+              data-testid="day-test[9]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -288,6 +356,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[10]",
+                },
+              }
+            }
             date={2020-02-05T00:00:00.000Z}
             dayLabel="5"
             focusedDate={null}
@@ -314,6 +389,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day"
+              data-testid="day-test[10]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -329,6 +405,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[11]",
+                },
+              }
+            }
             date={2020-02-06T00:00:00.000Z}
             dayLabel="6"
             focusedDate={null}
@@ -355,6 +438,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day"
+              data-testid="day-test[11]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -370,6 +454,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[12]",
+                },
+              }
+            }
             date={2020-02-07T00:00:00.000Z}
             dayLabel="7"
             focusedDate={null}
@@ -396,6 +487,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day mfui-day_active"
+              data-testid="day-test[12]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -411,6 +503,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[13]",
+                },
+              }
+            }
             date={2020-02-08T00:00:00.000Z}
             dayLabel="8"
             focusedDate={null}
@@ -437,6 +536,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day"
+              data-testid="day-test[13]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -452,6 +552,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[14]",
+                },
+              }
+            }
             date={2020-02-09T00:00:00.000Z}
             dayLabel="9"
             focusedDate={null}
@@ -478,6 +585,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day mfui-day_sunday"
+              data-testid="day-test[14]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -493,6 +601,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[15]",
+                },
+              }
+            }
             date={2020-02-10T00:00:00.000Z}
             dayLabel="10"
             focusedDate={null}
@@ -519,6 +634,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day mfui-day_monday"
+              data-testid="day-test[15]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -534,6 +650,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[16]",
+                },
+              }
+            }
             date={2020-02-11T00:00:00.000Z}
             dayLabel="11"
             focusedDate={null}
@@ -560,6 +683,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day"
+              data-testid="day-test[16]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -575,6 +699,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[17]",
+                },
+              }
+            }
             date={2020-02-12T00:00:00.000Z}
             dayLabel="12"
             focusedDate={null}
@@ -601,6 +732,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day"
+              data-testid="day-test[17]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -616,6 +748,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[18]",
+                },
+              }
+            }
             date={2020-02-13T00:00:00.000Z}
             dayLabel="13"
             focusedDate={null}
@@ -642,6 +781,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day"
+              data-testid="day-test[18]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -657,6 +797,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[19]",
+                },
+              }
+            }
             date={2020-02-14T00:00:00.000Z}
             dayLabel="14"
             focusedDate={null}
@@ -683,6 +830,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day"
+              data-testid="day-test[19]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -698,6 +846,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[20]",
+                },
+              }
+            }
             date={2020-02-15T00:00:00.000Z}
             dayLabel="15"
             focusedDate={null}
@@ -724,6 +879,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day"
+              data-testid="day-test[20]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -739,6 +895,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[21]",
+                },
+              }
+            }
             date={2020-02-16T00:00:00.000Z}
             dayLabel="16"
             focusedDate={null}
@@ -765,6 +928,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day mfui-day_sunday"
+              data-testid="day-test[21]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -780,6 +944,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[22]",
+                },
+              }
+            }
             date={2020-02-17T00:00:00.000Z}
             dayLabel="17"
             focusedDate={null}
@@ -806,6 +977,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day mfui-day_monday"
+              data-testid="day-test[22]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -821,6 +993,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[23]",
+                },
+              }
+            }
             date={2020-02-18T00:00:00.000Z}
             dayLabel="18"
             focusedDate={null}
@@ -847,6 +1026,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day"
+              data-testid="day-test[23]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -862,6 +1042,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[24]",
+                },
+              }
+            }
             date={2020-02-19T00:00:00.000Z}
             dayLabel="19"
             focusedDate={null}
@@ -888,6 +1075,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day"
+              data-testid="day-test[24]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -903,6 +1091,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[25]",
+                },
+              }
+            }
             date={2020-02-20T00:00:00.000Z}
             dayLabel="20"
             focusedDate={null}
@@ -929,6 +1124,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day"
+              data-testid="day-test[25]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -944,6 +1140,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[26]",
+                },
+              }
+            }
             date={2020-02-21T00:00:00.000Z}
             dayLabel="21"
             focusedDate={null}
@@ -970,6 +1173,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day"
+              data-testid="day-test[26]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -985,6 +1189,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[27]",
+                },
+              }
+            }
             date={2020-02-22T00:00:00.000Z}
             dayLabel="22"
             focusedDate={null}
@@ -1011,6 +1222,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day"
+              data-testid="day-test[27]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1026,6 +1238,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[28]",
+                },
+              }
+            }
             date={2020-02-23T00:00:00.000Z}
             dayLabel="23"
             focusedDate={null}
@@ -1052,6 +1271,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day mfui-day_sunday"
+              data-testid="day-test[28]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1067,6 +1287,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[29]",
+                },
+              }
+            }
             date={2020-02-24T00:00:00.000Z}
             dayLabel="24"
             focusedDate={null}
@@ -1093,6 +1320,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day mfui-day_monday"
+              data-testid="day-test[29]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1108,6 +1336,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[30]",
+                },
+              }
+            }
             date={2020-02-25T00:00:00.000Z}
             dayLabel="25"
             focusedDate={null}
@@ -1134,6 +1369,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day"
+              data-testid="day-test[30]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1149,6 +1385,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[31]",
+                },
+              }
+            }
             date={2020-02-26T00:00:00.000Z}
             dayLabel="26"
             focusedDate={null}
@@ -1175,6 +1418,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[31]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1190,6 +1434,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[32]",
+                },
+              }
+            }
             date={2020-02-27T00:00:00.000Z}
             dayLabel="27"
             focusedDate={null}
@@ -1216,6 +1467,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[32]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1231,6 +1483,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[33]",
+                },
+              }
+            }
             date={2020-02-28T00:00:00.000Z}
             dayLabel="28"
             focusedDate={null}
@@ -1257,6 +1516,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[33]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1272,6 +1532,13 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[34]",
+                },
+              }
+            }
             date={2020-02-29T00:00:00.000Z}
             dayLabel="29"
             focusedDate={null}
@@ -1298,6 +1565,7 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
           >
             <button
               className="mfui-day mfui-day_disabled mfui-day_last"
+              data-testid="day-test[34]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1322,6 +1590,25 @@ exports[`<Calendar /> snapshots renders calendar with single date 1`] = `
 exports[`<Calendar /> snapshots renders calendar without chosen dates if they are blocked 1`] = `
 <Calendar
   className="rootClass"
+  dataAttrs={
+    Object {
+      "arrowLeft": Object {
+        "data-testid": "arrowLeft-test",
+      },
+      "arrowRight": Object {
+        "data-testid": "arrowRight-test",
+      },
+      "day": Object {
+        "data-testid": "day-test",
+      },
+      "month": Object {
+        "data-testid": "month-test",
+      },
+      "root": Object {
+        "data-testid": "root",
+      },
+    }
+  }
   endDate={2020-02-27T00:00:00.000Z}
   maxBookingDate={2020-02-25T00:00:00.000Z}
   minBookingDate={2020-02-03T00:00:00.000Z}
@@ -1330,8 +1617,22 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
 >
   <div
     className="mfui-calendar rootClass"
+    data-testid="root"
   >
     <Month
+      dataAttrs={
+        Object {
+          "arrowLeft": Object {
+            "data-testid": "arrowLeft-test",
+          },
+          "arrowRight": Object {
+            "data-testid": "arrowRight-test",
+          },
+          "root": Object {
+            "data-testid": "month-test",
+          },
+        }
+      }
       goToNextMonth={[Function]}
       goToPreviousMonth={[Function]}
       isNextMonthDisabled={false}
@@ -1353,12 +1654,14 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
     >
       <div
         className="mfui-month"
+        data-testid="month-test"
       >
         <div
           className="mfui-month__header"
         >
           <test-file-stub
             className="mfui-month__arrow"
+            data-testid="arrowLeft-test"
             onClick={[Function]}
             onKeyDown={[Function]}
             role="button"
@@ -1371,6 +1674,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           </span>
           <test-file-stub
             className="mfui-month__arrow"
+            data-testid="arrowRight-test"
             onClick={[Function]}
             onKeyDown={[Function]}
             role="button"
@@ -1430,6 +1734,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             key="0"
           />
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[2]",
+                },
+              }
+            }
             date={2020-12-01T00:00:00.000Z}
             dayLabel="1"
             focusedDate={null}
@@ -1456,6 +1767,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled mfui-day_first"
+              data-testid="day-test[2]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1471,6 +1783,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[3]",
+                },
+              }
+            }
             date={2020-12-02T00:00:00.000Z}
             dayLabel="2"
             focusedDate={null}
@@ -1497,6 +1816,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[3]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1512,6 +1832,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[4]",
+                },
+              }
+            }
             date={2020-12-03T00:00:00.000Z}
             dayLabel="3"
             focusedDate={null}
@@ -1538,6 +1865,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[4]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1553,6 +1881,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[5]",
+                },
+              }
+            }
             date={2020-12-04T00:00:00.000Z}
             dayLabel="4"
             focusedDate={null}
@@ -1579,6 +1914,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[5]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1594,6 +1930,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[6]",
+                },
+              }
+            }
             date={2020-12-05T00:00:00.000Z}
             dayLabel="5"
             focusedDate={null}
@@ -1620,6 +1963,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[6]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1635,6 +1979,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[7]",
+                },
+              }
+            }
             date={2020-12-06T00:00:00.000Z}
             dayLabel="6"
             focusedDate={null}
@@ -1661,6 +2012,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled mfui-day_sunday"
+              data-testid="day-test[7]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1676,6 +2028,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[8]",
+                },
+              }
+            }
             date={2020-12-07T00:00:00.000Z}
             dayLabel="7"
             focusedDate={null}
@@ -1702,6 +2061,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled mfui-day_monday"
+              data-testid="day-test[8]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1717,6 +2077,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[9]",
+                },
+              }
+            }
             date={2020-12-08T00:00:00.000Z}
             dayLabel="8"
             focusedDate={null}
@@ -1743,6 +2110,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[9]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1758,6 +2126,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[10]",
+                },
+              }
+            }
             date={2020-12-09T00:00:00.000Z}
             dayLabel="9"
             focusedDate={null}
@@ -1784,6 +2159,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[10]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1799,6 +2175,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[11]",
+                },
+              }
+            }
             date={2020-12-10T00:00:00.000Z}
             dayLabel="10"
             focusedDate={null}
@@ -1825,6 +2208,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[11]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1840,6 +2224,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[12]",
+                },
+              }
+            }
             date={2020-12-11T00:00:00.000Z}
             dayLabel="11"
             focusedDate={null}
@@ -1866,6 +2257,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[12]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1881,6 +2273,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[13]",
+                },
+              }
+            }
             date={2020-12-12T00:00:00.000Z}
             dayLabel="12"
             focusedDate={null}
@@ -1907,6 +2306,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[13]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1922,6 +2322,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[14]",
+                },
+              }
+            }
             date={2020-12-13T00:00:00.000Z}
             dayLabel="13"
             focusedDate={null}
@@ -1948,6 +2355,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled mfui-day_sunday"
+              data-testid="day-test[14]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -1963,6 +2371,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[15]",
+                },
+              }
+            }
             date={2020-12-14T00:00:00.000Z}
             dayLabel="14"
             focusedDate={null}
@@ -1989,6 +2404,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled mfui-day_monday"
+              data-testid="day-test[15]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2004,6 +2420,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[16]",
+                },
+              }
+            }
             date={2020-12-15T00:00:00.000Z}
             dayLabel="15"
             focusedDate={null}
@@ -2030,6 +2453,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[16]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2045,6 +2469,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[17]",
+                },
+              }
+            }
             date={2020-12-16T00:00:00.000Z}
             dayLabel="16"
             focusedDate={null}
@@ -2071,6 +2502,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[17]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2086,6 +2518,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[18]",
+                },
+              }
+            }
             date={2020-12-17T00:00:00.000Z}
             dayLabel="17"
             focusedDate={null}
@@ -2112,6 +2551,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[18]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2127,6 +2567,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[19]",
+                },
+              }
+            }
             date={2020-12-18T00:00:00.000Z}
             dayLabel="18"
             focusedDate={null}
@@ -2153,6 +2600,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[19]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2168,6 +2616,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[20]",
+                },
+              }
+            }
             date={2020-12-19T00:00:00.000Z}
             dayLabel="19"
             focusedDate={null}
@@ -2194,6 +2649,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[20]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2209,6 +2665,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[21]",
+                },
+              }
+            }
             date={2020-12-20T00:00:00.000Z}
             dayLabel="20"
             focusedDate={null}
@@ -2235,6 +2698,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled mfui-day_sunday"
+              data-testid="day-test[21]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2250,6 +2714,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[22]",
+                },
+              }
+            }
             date={2020-12-21T00:00:00.000Z}
             dayLabel="21"
             focusedDate={null}
@@ -2276,6 +2747,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled mfui-day_monday"
+              data-testid="day-test[22]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2291,6 +2763,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[23]",
+                },
+              }
+            }
             date={2020-12-22T00:00:00.000Z}
             dayLabel="22"
             focusedDate={null}
@@ -2317,6 +2796,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[23]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2332,6 +2812,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[24]",
+                },
+              }
+            }
             date={2020-12-23T00:00:00.000Z}
             dayLabel="23"
             focusedDate={null}
@@ -2358,6 +2845,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[24]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2373,6 +2861,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[25]",
+                },
+              }
+            }
             date={2020-12-24T00:00:00.000Z}
             dayLabel="24"
             focusedDate={null}
@@ -2399,6 +2894,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[25]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2414,6 +2910,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[26]",
+                },
+              }
+            }
             date={2020-12-25T00:00:00.000Z}
             dayLabel="25"
             focusedDate={null}
@@ -2440,6 +2943,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[26]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2455,6 +2959,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[27]",
+                },
+              }
+            }
             date={2020-12-26T00:00:00.000Z}
             dayLabel="26"
             focusedDate={null}
@@ -2481,6 +2992,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[27]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2496,6 +3008,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[28]",
+                },
+              }
+            }
             date={2020-12-27T00:00:00.000Z}
             dayLabel="27"
             focusedDate={null}
@@ -2522,6 +3041,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled mfui-day_sunday"
+              data-testid="day-test[28]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2537,6 +3057,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[29]",
+                },
+              }
+            }
             date={2020-12-28T00:00:00.000Z}
             dayLabel="28"
             focusedDate={null}
@@ -2563,6 +3090,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled mfui-day_monday"
+              data-testid="day-test[29]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2578,6 +3106,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[30]",
+                },
+              }
+            }
             date={2020-12-29T00:00:00.000Z}
             dayLabel="29"
             focusedDate={null}
@@ -2604,6 +3139,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[30]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2619,6 +3155,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[31]",
+                },
+              }
+            }
             date={2020-12-30T00:00:00.000Z}
             dayLabel="30"
             focusedDate={null}
@@ -2645,6 +3188,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled"
+              data-testid="day-test[31]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2660,6 +3204,13 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
             </button>
           </Day>
           <Day
+            dataAttrs={
+              Object {
+                "root": Object {
+                  "data-testid": "day-test[32]",
+                },
+              }
+            }
             date={2020-12-31T00:00:00.000Z}
             dayLabel="31"
             focusedDate={null}
@@ -2686,6 +3237,7 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
           >
             <button
               className="mfui-day mfui-day_disabled mfui-day_last"
+              data-testid="day-test[32]"
               onClick={[Function]}
               onKeyDown={[Function]}
               onMouseEnter={[Function]}
@@ -2710,8 +3262,22 @@ exports[`<Calendar /> snapshots renders calendar without chosen dates if they ar
 exports[`<Calendar /> snapshots renders with all props 1`] = `
 <div
   className="mfui-calendar rootClass"
+  data-testid="root"
 >
   <Month
+    dataAttrs={
+      Object {
+        "arrowLeft": Object {
+          "data-testid": "arrowLeft-test",
+        },
+        "arrowRight": Object {
+          "data-testid": "arrowRight-test",
+        },
+        "root": Object {
+          "data-testid": "month-test",
+        },
+      }
+    }
     goToNextMonth={[Function]}
     goToPreviousMonth={[Function]}
     isNextMonthDisabled={true}
@@ -2747,6 +3313,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       key="4"
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[6]",
+          },
+        }
+      }
       date={2020-02-01T00:00:00.000Z}
       dayLabel="1"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -2772,6 +3345,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[7]",
+          },
+        }
+      }
       date={2020-02-02T00:00:00.000Z}
       dayLabel="2"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -2797,6 +3377,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[8]",
+          },
+        }
+      }
       date={2020-02-03T00:00:00.000Z}
       dayLabel="3"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -2822,6 +3409,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[9]",
+          },
+        }
+      }
       date={2020-02-04T00:00:00.000Z}
       dayLabel="4"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -2847,6 +3441,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[10]",
+          },
+        }
+      }
       date={2020-02-05T00:00:00.000Z}
       dayLabel="5"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -2872,6 +3473,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[11]",
+          },
+        }
+      }
       date={2020-02-06T00:00:00.000Z}
       dayLabel="6"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -2897,6 +3505,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[12]",
+          },
+        }
+      }
       date={2020-02-07T00:00:00.000Z}
       dayLabel="7"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -2922,6 +3537,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[13]",
+          },
+        }
+      }
       date={2020-02-08T00:00:00.000Z}
       dayLabel="8"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -2947,6 +3569,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[14]",
+          },
+        }
+      }
       date={2020-02-09T00:00:00.000Z}
       dayLabel="9"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -2972,6 +3601,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[15]",
+          },
+        }
+      }
       date={2020-02-10T00:00:00.000Z}
       dayLabel="10"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -2997,6 +3633,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[16]",
+          },
+        }
+      }
       date={2020-02-11T00:00:00.000Z}
       dayLabel="11"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3022,6 +3665,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[17]",
+          },
+        }
+      }
       date={2020-02-12T00:00:00.000Z}
       dayLabel="12"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3047,6 +3697,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[18]",
+          },
+        }
+      }
       date={2020-02-13T00:00:00.000Z}
       dayLabel="13"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3072,6 +3729,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[19]",
+          },
+        }
+      }
       date={2020-02-14T00:00:00.000Z}
       dayLabel="14"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3097,6 +3761,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[20]",
+          },
+        }
+      }
       date={2020-02-15T00:00:00.000Z}
       dayLabel="15"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3122,6 +3793,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[21]",
+          },
+        }
+      }
       date={2020-02-16T00:00:00.000Z}
       dayLabel="16"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3147,6 +3825,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[22]",
+          },
+        }
+      }
       date={2020-02-17T00:00:00.000Z}
       dayLabel="17"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3172,6 +3857,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[23]",
+          },
+        }
+      }
       date={2020-02-18T00:00:00.000Z}
       dayLabel="18"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3197,6 +3889,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[24]",
+          },
+        }
+      }
       date={2020-02-19T00:00:00.000Z}
       dayLabel="19"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3222,6 +3921,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[25]",
+          },
+        }
+      }
       date={2020-02-20T00:00:00.000Z}
       dayLabel="20"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3247,6 +3953,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[26]",
+          },
+        }
+      }
       date={2020-02-21T00:00:00.000Z}
       dayLabel="21"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3272,6 +3985,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[27]",
+          },
+        }
+      }
       date={2020-02-22T00:00:00.000Z}
       dayLabel="22"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3297,6 +4017,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[28]",
+          },
+        }
+      }
       date={2020-02-23T00:00:00.000Z}
       dayLabel="23"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3322,6 +4049,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[29]",
+          },
+        }
+      }
       date={2020-02-24T00:00:00.000Z}
       dayLabel="24"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3347,6 +4081,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[30]",
+          },
+        }
+      }
       date={2020-02-25T00:00:00.000Z}
       dayLabel="25"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3372,6 +4113,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[31]",
+          },
+        }
+      }
       date={2020-02-26T00:00:00.000Z}
       dayLabel="26"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3397,6 +4145,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[32]",
+          },
+        }
+      }
       date={2020-02-27T00:00:00.000Z}
       dayLabel="27"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3422,6 +4177,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[33]",
+          },
+        }
+      }
       date={2020-02-28T00:00:00.000Z}
       dayLabel="28"
       focusedDate={2020-02-07T00:00:00.000Z}
@@ -3447,6 +4209,13 @@ exports[`<Calendar /> snapshots renders with all props 1`] = `
       onResetDates={[Function]}
     />
     <Day
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "day-test[34]",
+          },
+        }
+      }
       date={2020-02-29T00:00:00.000Z}
       dayLabel="29"
       focusedDate={2020-02-07T00:00:00.000Z}

--- a/packages/ui-core/src/components/Calendar/components/Day/Day.test.tsx
+++ b/packages/ui-core/src/components/Calendar/components/Day/Day.test.tsx
@@ -3,6 +3,9 @@ import { shallow } from 'enzyme';
 import Day, { IDayProps } from './Day';
 
 const props: IDayProps = {
+    dataAttrs: {
+        root: { 'data-testid': 'root' },
+    },
     dayLabel: 'Пн',
     date: new Date(1994, 9, 30),
     focusedDate: new Date(1994, 9, 30),

--- a/packages/ui-core/src/components/Calendar/components/Day/Day.tsx
+++ b/packages/ui-core/src/components/Calendar/components/Day/Day.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useDay } from '@datepicker-react/hooks';
-import { cnCreate } from '@megafon/ui-helpers';
+import { cnCreate, filterDataAttrs } from '@megafon/ui-helpers';
 import isFirstDayOfMonth from 'date-fns/isFirstDayOfMonth';
 import isLastDayOfMonth from 'date-fns/isLastDayOfMonth';
 import isMonday from 'date-fns/isMonday';
@@ -9,6 +9,9 @@ import PropTypes from 'prop-types';
 import './Day.less';
 
 export interface IDayPickerProps {
+    dataAttrs?: {
+        root?: Record<string, string>;
+    };
     isDateSelected: (date: Date) => boolean;
     isDateHovered: (date: Date) => boolean;
     isFirstOrLastSelectedDate: (date: Date) => boolean;
@@ -30,7 +33,7 @@ export type DayType = {
 export type IDayProps = IDayPickerProps & DayType;
 
 const cn = cnCreate('mfui-day');
-const Day: React.FC<IDayProps> = ({ isBetween = false, dayLabel, date, onMouseLeave, ...pickerProps }) => {
+const Day: React.FC<IDayProps> = ({ dataAttrs, isBetween = false, dayLabel, date, onMouseLeave, ...pickerProps }) => {
     const dayRef = React.useRef(null);
 
     const {
@@ -59,6 +62,7 @@ const Day: React.FC<IDayProps> = ({ isBetween = false, dayLabel, date, onMouseLe
 
     return (
         <button
+            {...filterDataAttrs(dataAttrs?.root)}
             onClick={onClick}
             onKeyDown={onKeyDown}
             onMouseEnter={onMouseEnter}
@@ -74,6 +78,9 @@ const Day: React.FC<IDayProps> = ({ isBetween = false, dayLabel, date, onMouseLe
 };
 
 Day.propTypes = {
+    dataAttrs: PropTypes.shape({
+        root: PropTypes.objectOf(PropTypes.string.isRequired),
+    }),
     dayLabel: PropTypes.string,
     date: PropTypes.instanceOf(Date).isRequired,
     focusedDate: PropTypes.instanceOf(Date),

--- a/packages/ui-core/src/components/Calendar/components/Day/__snapshots__/Day.test.tsx.snap
+++ b/packages/ui-core/src/components/Calendar/components/Day/__snapshots__/Day.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`<Day /> snapshots renders Day with all props 1`] = `
 <button
   className="mfui-day mfui-day_between mfui-day_sunday"
+  data-testid="root"
   onClick={[Function]}
   onKeyDown={[Function]}
   onMouseEnter={[Function]}
@@ -21,6 +22,7 @@ exports[`<Day /> snapshots renders Day with all props 1`] = `
 exports[`<Day /> snapshots renders Day with required props 1`] = `
 <button
   className="mfui-day mfui-day_sunday"
+  data-testid="root"
   onClick={[Function]}
   onKeyDown={[Function]}
   onMouseEnter={[Function]}
@@ -37,6 +39,7 @@ exports[`<Day /> snapshots renders Day with required props 1`] = `
 exports[`<Day /> snapshots should return empty div if label is not provided 1`] = `
 <button
   className="mfui-day mfui-day_sunday"
+  data-testid="root"
   onClick={[Function]}
   onKeyDown={[Function]}
   onMouseEnter={[Function]}

--- a/packages/ui-core/src/components/Calendar/components/Month/Month.test.tsx
+++ b/packages/ui-core/src/components/Calendar/components/Month/Month.test.tsx
@@ -17,6 +17,11 @@ const enterEvent = {
 } as React.KeyboardEvent;
 
 const props: IMonthProps = {
+    dataAttrs: {
+        root: { 'data-testid': 'root-test' },
+        arrowLeft: { 'data-testid': 'arrowLeft-test' },
+        arrowRight: { 'data-testid': 'arrowRight-test' },
+    },
     isNextMonthDisabled: false,
     isPrevMonthDisabled: false,
     year: 1994,

--- a/packages/ui-core/src/components/Calendar/components/Month/Month.tsx
+++ b/packages/ui-core/src/components/Calendar/components/Month/Month.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FirstDayOfWeek, MonthType } from '@datepicker-react/hooks';
-import { AccessibilityEventType, checkEventIsClickOrEnterPress, cnCreate } from '@megafon/ui-helpers';
+import { AccessibilityEventType, checkEventIsClickOrEnterPress, cnCreate, filterDataAttrs } from '@megafon/ui-helpers';
 import ArrowLeft from '@megafon/ui-icons/system-16-arrow-list_left_16.svg';
 import ArrowRight from '@megafon/ui-icons/system-16-arrow-list_right_16.svg';
 import './Month.less';
@@ -14,6 +14,11 @@ export interface IMonthPickerProps {
 }
 
 export interface IMonthProps {
+    dataAttrs?: {
+        root?: Record<string, string>;
+        arrowLeft?: Record<string, string>;
+        arrowRight?: Record<string, string>;
+    };
     isPrevMonthDisabled: boolean;
     isNextMonthDisabled: boolean;
     year: number;
@@ -25,6 +30,7 @@ export interface IMonthProps {
 
 const cn = cnCreate('mfui-month');
 const Month: React.FC<IMonthProps> = ({
+    dataAttrs,
     isPrevMonthDisabled,
     isNextMonthDisabled,
     year,
@@ -54,9 +60,10 @@ const Month: React.FC<IMonthProps> = ({
     };
 
     return (
-        <div className={cn()}>
+        <div {...filterDataAttrs(dataAttrs?.root)} className={cn()}>
             <div className={cn('header')}>
                 <ArrowLeft
+                    {...filterDataAttrs(dataAttrs?.arrowLeft)}
                     role="button"
                     tabIndex={getTabIndex(!isPrevMonthDisabled)}
                     className={cn('arrow', { disabled: isPrevMonthDisabled })}
@@ -65,6 +72,7 @@ const Month: React.FC<IMonthProps> = ({
                 />
                 <span className={cn('title')}>{`${monthLabel} ${year}`}</span>
                 <ArrowRight
+                    {...filterDataAttrs(dataAttrs?.arrowRight)}
                     role="button"
                     tabIndex={getTabIndex(!isNextMonthDisabled)}
                     className={cn('arrow', { disabled: isNextMonthDisabled })}
@@ -85,6 +93,11 @@ const Month: React.FC<IMonthProps> = ({
 };
 
 Month.propTypes = {
+    dataAttrs: PropTypes.shape({
+        root: PropTypes.objectOf(PropTypes.string.isRequired),
+        arrowLeft: PropTypes.objectOf(PropTypes.string.isRequired),
+        arrowRight: PropTypes.objectOf(PropTypes.string.isRequired),
+    }),
     isPrevMonthDisabled: PropTypes.bool.isRequired,
     isNextMonthDisabled: PropTypes.bool.isRequired,
     year: PropTypes.number.isRequired,

--- a/packages/ui-core/src/components/Calendar/components/Month/__snapshots__/Month.test.tsx.snap
+++ b/packages/ui-core/src/components/Calendar/components/Month/__snapshots__/Month.test.tsx.snap
@@ -3,12 +3,14 @@
 exports[`<Month /> snapshots renders component with props 1`] = `
 <div
   className="mfui-month"
+  data-testid="root-test"
 >
   <div
     className="mfui-month__header"
   >
     <test-file-stub
       className="mfui-month__arrow"
+      data-testid="arrowLeft-test"
       onClick={[Function]}
       onKeyDown={[Function]}
       role="button"
@@ -21,6 +23,7 @@ exports[`<Month /> snapshots renders component with props 1`] = `
     </span>
     <test-file-stub
       className="mfui-month__arrow"
+      data-testid="arrowRight-test"
       onClick={[Function]}
       onKeyDown={[Function]}
       role="button"
@@ -54,12 +57,14 @@ exports[`<Month /> snapshots renders component with props 1`] = `
 exports[`<Month /> snapshots renders component with props disabled arrows 1`] = `
 <div
   className="mfui-month"
+  data-testid="root-test"
 >
   <div
     className="mfui-month__header"
   >
     <test-file-stub
       className="mfui-month__arrow mfui-month__arrow_disabled"
+      data-testid="arrowLeft-test"
       onClick={[Function]}
       onKeyDown={[Function]}
       role="button"
@@ -72,6 +77,7 @@ exports[`<Month /> snapshots renders component with props disabled arrows 1`] = 
     </span>
     <test-file-stub
       className="mfui-month__arrow mfui-month__arrow_disabled"
+      data-testid="arrowRight-test"
       onClick={[Function]}
       onKeyDown={[Function]}
       role="button"

--- a/packages/ui-core/src/components/Carousel/Carousel.tsx
+++ b/packages/ui-core/src/components/Carousel/Carousel.tsx
@@ -237,12 +237,16 @@ const Carousel: React.FC<ICarouselProps> = ({
         }
     };
 
+    const handleNavDisplay = (swiper: SwiperCore) => {
+        setBeginning(swiper.isBeginning);
+        setEnd(swiper.isEnd);
+        setLocked(swiper.isBeginning && swiper.isEnd);
+    };
+
     // https://github.com/nolimits4web/Swiper/issues/2346
     const handleSwiperResize = React.useCallback(() => {
         throttle((swiper: SwiperCore) => {
-            setBeginning(swiper.isBeginning);
-            setEnd(swiper.isEnd);
-            setLocked(swiper.isBeginning && swiper.isEnd);
+            handleNavDisplay(swiper);
 
             if (swiper.params.slidesPerView === SlidesPerView.AUTO) {
                 swiper.slides.css('width', '');
@@ -270,6 +274,21 @@ const Carousel: React.FC<ICarouselProps> = ({
     const disableFocusOnSlideClick = (e: React.MouseEvent) => {
         e.nativeEvent.preventDefault();
     };
+
+    React.useEffect(() => {
+        if (!swiperInstance) {
+            return undefined;
+        }
+
+        const windowResizeHandler = () => handleNavDisplay(swiperInstance);
+        const windowResizeHandlerThrottled = throttle(windowResizeHandler, throttleTime.resize);
+
+        window.addEventListener('resize', windowResizeHandlerThrottled);
+
+        return () => {
+            window.removeEventListener('resize', windowResizeHandlerThrottled);
+        };
+    }, [swiperInstance]);
 
     return (
         <div

--- a/packages/ui-core/src/components/Collapse/Collapse.tsx
+++ b/packages/ui-core/src/components/Collapse/Collapse.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useCallback, useEffect } from 'react';
 import { filterDataAttrs } from '@megafon/ui-helpers';
 import * as PropTypes from 'prop-types';
 
@@ -18,7 +19,10 @@ type CollapseProps = CollapseDefaultProps & {
     children: React.ReactNode;
 };
 
-const BROWSER_DELAY = 100;
+const { sin, cos, min, PI } = Math;
+
+const easeOutSine = (progress: number): number => sin((progress * PI) / 2);
+const easeInSine = (progress: number): number => 1 - cos((progress * PI) / 2);
 
 const Collapse = (props: CollapseProps): React.FunctionComponentElement<CollapseProps> => {
     const {
@@ -30,50 +34,83 @@ const Collapse = (props: CollapseProps): React.FunctionComponentElement<Collapse
         isOpened,
         dataAttrs,
     } = props;
-    const canUpdate = React.useRef<boolean>(false);
-    const timer = React.useRef<number | undefined>(undefined);
-    const rootNode = React.useRef<HTMLInputElement>(null);
-    const [height, setHeight] = React.useState<string>('0px');
-    const transition: string = animation ? `height ${animationDuration / 1000}s` : 'none';
+
     const duration: number = animation ? animationDuration : 0;
 
-    const animateSlide = (finalHeight: string, delay: number): void => {
+    const animationStart = React.useRef<null | number>(null);
+    const animationId = React.useRef<null | number>(null);
+    const canUpdate = React.useRef<boolean>(false);
+    const rootNode = React.useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        animationId.current && window.cancelAnimationFrame(animationId.current);
+    }, [isOpened]);
+
+    const animateSlide = useCallback(
+        (contentHeight: number, animationTime: number, timePassed: number, isOpenAction = false): void => {
+            if (!rootNode.current) {
+                return;
+            }
+
+            if (!animationStart.current) {
+                animationStart.current = timePassed;
+            }
+
+            const runtime = timePassed - animationStart.current;
+            const progress = animationTime ? min(runtime / animationTime, 1) : 1;
+
+            const isAnimationInProgress = progress < 1;
+            const nextHeight = isOpenAction
+                ? easeOutSine(progress) * contentHeight
+                : contentHeight - easeInSine(progress) * contentHeight;
+
+            rootNode.current.style.height = `${nextHeight}px`;
+
+            if (isAnimationInProgress) {
+                animationId.current = window.requestAnimationFrame(time =>
+                    animateSlide(contentHeight, animationTime, time, isOpenAction),
+                );
+            } else {
+                animationStart.current = null;
+                animationId.current = null;
+            }
+        },
+        [],
+    );
+
+    useEffect(() => {
         if (!rootNode.current) {
             return;
         }
-        setHeight(`${rootNode.current.scrollHeight}px`);
-        timer.current = window.setTimeout(() => {
-            setHeight(finalHeight);
-        }, delay);
-    };
 
-    React.useEffect(() => {
+        const { scrollHeight = 0 } = rootNode.current;
+
         switch (true) {
             case !canUpdate.current && isOpened:
-                setHeight('auto');
+                rootNode.current.style.height = 'auto';
+
                 break;
             case !canUpdate.current && !isOpened:
-                setHeight('0px');
+                rootNode.current.style.height = '0px';
+
                 break;
             case isOpened:
-                animateSlide('auto', duration);
+                animationId.current = window.requestAnimationFrame(timePassed =>
+                    animateSlide(scrollHeight, duration, timePassed, true),
+                );
+
                 break;
             default:
-                animateSlide('0px', BROWSER_DELAY);
+                animationId.current = window.requestAnimationFrame(timePassed =>
+                    animateSlide(scrollHeight, duration, timePassed),
+                );
         }
 
         canUpdate.current = true;
-
-        return (): void => clearTimeout(timer.current);
-    }, [isOpened, duration]);
+    }, [isOpened, duration, animateSlide]);
 
     return (
-        <div
-            {...filterDataAttrs(dataAttrs?.root)}
-            className={className}
-            style={{ overflow: 'hidden', height, transition }}
-            ref={rootNode}
-        >
+        <div {...filterDataAttrs(dataAttrs?.root)} className={className} style={{ overflow: 'hidden' }} ref={rootNode}>
             <div {...filterDataAttrs(dataAttrs?.inner)} className={classNameContainer}>
                 {children}
             </div>

--- a/packages/ui-core/src/components/ContentArea/ContentArea.less
+++ b/packages/ui-core/src/components/ContentArea/ContentArea.less
@@ -5,36 +5,42 @@
 @{b} {
     // mod: color
 
-    &_color_black {
-        background-color: var(--stcBlack);
-    }
-
-    &_color_white {
-        background-color: var(--stcWhite);
-    }
-
-    &_color_transparent {
+    &_background-color_transparent {
         background-color: transparent;
     }
 
-    &_color_green {
+    &_background-color_black {
+        background-color: var(--stcBlack);
+    }
+
+    &_background-color_white {
+        background-color: var(--stcWhite);
+    }
+
+    &_background-color_green {
         background-color: var(--brandGreen);
     }
 
-    &_color_purple {
+    &_background-color_purple {
         background-color: var(--brandPurple);
     }
 
-    &_color_spbSky0 {
+    &_background-color_spbSky0 {
         background-color: var(--spbSky0);
     }
 
-    &_color_spbSky1 {
+    &_background-color_spbSky1 {
         background-color: var(--spbSky1);
     }
 
-    &_color_spbSky2 {
+    &_background-color_spbSky2 {
         background-color: var(--spbSky2);
+    }
+
+    /* deprecated */
+
+    &_background-color_default {
+        background-color: var(--content);
     }
 
     &__inner {
@@ -88,35 +94,41 @@
 
     // mod: color
 
-    &__inner_color_black {
-        background-color: var(--stcBlack);
-    }
-
-    &__inner_color_white {
-        background-color: var(--stcWhite);
-    }
-
-    &__inner_color_transparent {
+    &__inner_background-color_transparent {
         background-color: transparent;
     }
 
-    &__inner_color_green {
+    &__inner_background-color_black {
+        background-color: var(--stcBlack);
+    }
+
+    &__inner_background-color_white {
+        background-color: var(--stcWhite);
+    }
+
+    &__inner_background-color_green {
         background-color: var(--brandGreen);
     }
 
-    &__inner_color_purple {
+    &__inner_background-color_purple {
         background-color: var(--brandPurple);
     }
 
-    &__inner_color_spbSky0 {
+    &__inner_background-color_spbSky0 {
         background-color: var(--spbSky0);
     }
 
-    &__inner_color_spbSky1 {
+    &__inner_background-color_spbSky1 {
         background-color: var(--spbSky1);
     }
 
-    &__inner_color_spbSky2 {
+    &__inner_background-color_spbSky2 {
         background-color: var(--spbSky2);
+    }
+
+    /* deprecated */
+
+    &__inner_background-color_default {
+        background-color: var(--content);
     }
 }

--- a/packages/ui-core/src/components/ContentArea/ContentArea.less
+++ b/packages/ui-core/src/components/ContentArea/ContentArea.less
@@ -5,8 +5,8 @@
 @{b} {
     // mod: color
 
-    &_color_default {
-        background-color: var(--content);
+    &_color_black {
+        background-color: var(--stcBlack);
     }
 
     &_color_white {
@@ -88,8 +88,8 @@
 
     // mod: color
 
-    &__inner_color_default {
-        background-color: var(--content);
+    &__inner_color_black {
+        background-color: var(--stcBlack);
     }
 
     &__inner_color_white {

--- a/packages/ui-core/src/components/ContentArea/ContentArea.tsx
+++ b/packages/ui-core/src/components/ContentArea/ContentArea.tsx
@@ -4,14 +4,16 @@ import * as PropTypes from 'prop-types';
 import './ContentArea.less';
 
 const BACKGROUND_COLORS = {
-    DEFAULT: 'default',
-    WHITE: 'white',
     TRANSPARENT: 'transparent',
+    BLACK: 'black',
+    WHITE: 'white',
     GREEN: 'green',
     PURPLE: 'purple',
     SPB_SKY_0: 'spbSky0',
     SPB_SKY_1: 'spbSky1',
     SPB_SKY_2: 'spbSky2',
+    // @deprecated
+    DEFAULT: 'default',
 } as const;
 
 export type BackgroundColorType = typeof BACKGROUND_COLORS[keyof typeof BACKGROUND_COLORS];
@@ -43,20 +45,20 @@ export interface IConrentAreaProps {
 
 const cn = cnCreate('mfui-content-area');
 const ContentArea: React.FC<IConrentAreaProps> = ({
-    outerBackgroundColor,
-    innerBackgroundColor,
+    outerBackgroundColor = 'transparent',
+    innerBackgroundColor = 'transparent',
     disableIndents,
     children,
     className,
     classes,
 }) => (
-    <div className={cn({ color: outerBackgroundColor }, [className, classes?.root])}>
+    <div className={cn({ 'background-color': outerBackgroundColor }, [className, classes?.root])}>
         <div
             className={cn(
                 'inner',
                 {
                     'disable-indents': disableIndents,
-                    color: innerBackgroundColor,
+                    'background-color': innerBackgroundColor,
                 },
                 classes?.inner,
             )}
@@ -75,11 +77,6 @@ ContentArea.propTypes = {
     }),
     outerBackgroundColor: PropTypes.oneOf(Object.values(BACKGROUND_COLORS)),
     innerBackgroundColor: PropTypes.oneOf(Object.values(BACKGROUND_COLORS)),
-};
-
-ContentArea.defaultProps = {
-    outerBackgroundColor: 'transparent',
-    innerBackgroundColor: 'transparent',
 };
 
 export default ContentArea;

--- a/packages/ui-core/src/components/ContentArea/__snapshots__/ContentArea.test.tsx.snap
+++ b/packages/ui-core/src/components/ContentArea/__snapshots__/ContentArea.test.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`<ContentArea /> render component when innerBackgroundColor with default 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_transparent"
+  className="mfui-content-area mfui-content-area_background-color_transparent"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_color_default"
+    className="mfui-content-area__inner mfui-content-area__inner_background-color_default"
   >
     some content
   </div>
@@ -14,10 +14,10 @@ exports[`<ContentArea /> render component when innerBackgroundColor with default
 
 exports[`<ContentArea /> render component when innerBackgroundColor with green 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_transparent"
+  className="mfui-content-area mfui-content-area_background-color_transparent"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_color_green"
+    className="mfui-content-area__inner mfui-content-area__inner_background-color_green"
   >
     some content
   </div>
@@ -26,10 +26,10 @@ exports[`<ContentArea /> render component when innerBackgroundColor with green 1
 
 exports[`<ContentArea /> render component when innerBackgroundColor with purple 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_transparent"
+  className="mfui-content-area mfui-content-area_background-color_transparent"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_color_purple"
+    className="mfui-content-area__inner mfui-content-area__inner_background-color_purple"
   >
     some content
   </div>
@@ -38,10 +38,10 @@ exports[`<ContentArea /> render component when innerBackgroundColor with purple 
 
 exports[`<ContentArea /> render component when innerBackgroundColor with spbSky0 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_transparent"
+  className="mfui-content-area mfui-content-area_background-color_transparent"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_color_spbSky0"
+    className="mfui-content-area__inner mfui-content-area__inner_background-color_spbSky0"
   >
     some content
   </div>
@@ -50,10 +50,10 @@ exports[`<ContentArea /> render component when innerBackgroundColor with spbSky0
 
 exports[`<ContentArea /> render component when innerBackgroundColor with spbSky1 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_transparent"
+  className="mfui-content-area mfui-content-area_background-color_transparent"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_color_spbSky1"
+    className="mfui-content-area__inner mfui-content-area__inner_background-color_spbSky1"
   >
     some content
   </div>
@@ -62,10 +62,10 @@ exports[`<ContentArea /> render component when innerBackgroundColor with spbSky1
 
 exports[`<ContentArea /> render component when innerBackgroundColor with spbSky2 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_transparent"
+  className="mfui-content-area mfui-content-area_background-color_transparent"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_color_spbSky2"
+    className="mfui-content-area__inner mfui-content-area__inner_background-color_spbSky2"
   >
     some content
   </div>
@@ -74,10 +74,10 @@ exports[`<ContentArea /> render component when innerBackgroundColor with spbSky2
 
 exports[`<ContentArea /> render component when innerBackgroundColor with transparent 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_transparent"
+  className="mfui-content-area mfui-content-area_background-color_transparent"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+    className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
   >
     some content
   </div>
@@ -86,10 +86,10 @@ exports[`<ContentArea /> render component when innerBackgroundColor with transpa
 
 exports[`<ContentArea /> render component when innerBackgroundColor with white 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_transparent"
+  className="mfui-content-area mfui-content-area_background-color_transparent"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_color_white"
+    className="mfui-content-area__inner mfui-content-area__inner_background-color_white"
   >
     some content
   </div>
@@ -98,10 +98,10 @@ exports[`<ContentArea /> render component when innerBackgroundColor with white 1
 
 exports[`<ContentArea /> render component when outerBackgroundColor with default 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_default"
+  className="mfui-content-area mfui-content-area_background-color_default"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+    className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
   >
     some content
   </div>
@@ -110,10 +110,10 @@ exports[`<ContentArea /> render component when outerBackgroundColor with default
 
 exports[`<ContentArea /> render component when outerBackgroundColor with green 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_green"
+  className="mfui-content-area mfui-content-area_background-color_green"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+    className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
   >
     some content
   </div>
@@ -122,10 +122,10 @@ exports[`<ContentArea /> render component when outerBackgroundColor with green 1
 
 exports[`<ContentArea /> render component when outerBackgroundColor with purple 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_purple"
+  className="mfui-content-area mfui-content-area_background-color_purple"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+    className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
   >
     some content
   </div>
@@ -134,10 +134,10 @@ exports[`<ContentArea /> render component when outerBackgroundColor with purple 
 
 exports[`<ContentArea /> render component when outerBackgroundColor with spbSky0 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_spbSky0"
+  className="mfui-content-area mfui-content-area_background-color_spbSky0"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+    className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
   >
     some content
   </div>
@@ -146,10 +146,10 @@ exports[`<ContentArea /> render component when outerBackgroundColor with spbSky0
 
 exports[`<ContentArea /> render component when outerBackgroundColor with spbSky1 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_spbSky1"
+  className="mfui-content-area mfui-content-area_background-color_spbSky1"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+    className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
   >
     some content
   </div>
@@ -158,10 +158,10 @@ exports[`<ContentArea /> render component when outerBackgroundColor with spbSky1
 
 exports[`<ContentArea /> render component when outerBackgroundColor with spbSky2 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_spbSky2"
+  className="mfui-content-area mfui-content-area_background-color_spbSky2"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+    className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
   >
     some content
   </div>
@@ -170,10 +170,10 @@ exports[`<ContentArea /> render component when outerBackgroundColor with spbSky2
 
 exports[`<ContentArea /> render component when outerBackgroundColor with transparent 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_transparent"
+  className="mfui-content-area mfui-content-area_background-color_transparent"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+    className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
   >
     some content
   </div>
@@ -182,10 +182,10 @@ exports[`<ContentArea /> render component when outerBackgroundColor with transpa
 
 exports[`<ContentArea /> render component when outerBackgroundColor with white 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_white"
+  className="mfui-content-area mfui-content-area_background-color_white"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+    className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
   >
     some content
   </div>
@@ -194,10 +194,10 @@ exports[`<ContentArea /> render component when outerBackgroundColor with white 1
 
 exports[`<ContentArea /> renders correctly with custom props 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_white className rootClass"
+  className="mfui-content-area mfui-content-area_background-color_white className rootClass"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_disable-indents_all mfui-content-area__inner_color_white innerClass"
+    className="mfui-content-area__inner mfui-content-area__inner_disable-indents_all mfui-content-area__inner_background-color_white innerClass"
   >
     <span>
       child
@@ -208,10 +208,10 @@ exports[`<ContentArea /> renders correctly with custom props 1`] = `
 
 exports[`<ContentArea /> renders correctly with default props 1`] = `
 <div
-  className="mfui-content-area mfui-content-area_color_transparent"
+  className="mfui-content-area mfui-content-area_background-color_transparent"
 >
   <div
-    className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+    className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
   >
     <span>
       child

--- a/packages/ui-core/src/components/ContentArea/doc/ContentArea.docz.tsx
+++ b/packages/ui-core/src/components/ContentArea/doc/ContentArea.docz.tsx
@@ -1,3 +1,11 @@
-export const wrapperStyles = {
+export const wrapperStyles: React.CSSProperties = {
     padding: '20px 0',
+};
+
+export const blockStyle: React.CSSProperties = {
+    display: 'inline-grid',
+    gridGap: '20px',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(100%, 1fr))',
+    alignItems: 'center',
+    width: '100%',
 };

--- a/packages/ui-core/src/components/ContentArea/doc/ContentArea.example.mdx
+++ b/packages/ui-core/src/components/ContentArea/doc/ContentArea.example.mdx
@@ -1,6 +1,6 @@
 import { Playground, Props } from 'docz';
 import ContentArea from '../ContentArea';
-import { wrapperStyles } from './ContentArea.docz';
+import { blockStyle, wrapperStyles } from './ContentArea.docz';
 
 ## Использование по умолчанию
 
@@ -15,9 +15,50 @@ import { wrapperStyles } from './ContentArea.docz';
 Фоновый цвет применяется ко всему компоненту
 
 <Playground style={wrapperStyles}>
+    <ContentArea outerBackgroundColor="white">
+        <div style={{ color: '#333333'}}>
+            (white) Подключение к домашнему интернету осуществляется в удобное для вас время по технологиям Ethernet, Docsis.
+            Монтажник проведёт все необходимые работы под ключ.
+        </div>
+    </ContentArea>
+
+    <ContentArea outerBackgroundColor="black">
+        <div style={{ color: '#ffffff'}}>
+            (black) Подключение к домашнему интернету осуществляется в удобное для вас время по технологиям Ethernet, Docsis.
+            Монтажник проведёт все необходимые работы под ключ.
+        </div>
+    </ContentArea>
+
     <ContentArea outerBackgroundColor="green">
-        <div style={{ color: 'white'}}>
-            Подключение к домашнему интернету осуществляется в удобное для вас время по технологиям Ethernet, Docsis.
+        <div style={{ color: '#ffffff'}}>
+            (green) Подключение к домашнему интернету осуществляется в удобное для вас время по технологиям Ethernet, Docsis.
+            Монтажник проведёт все необходимые работы под ключ.
+        </div>
+    </ContentArea>
+
+    <ContentArea outerBackgroundColor="purple">
+        <div style={{ color: '#ffffff'}}>
+            (purple) Подключение к домашнему интернету осуществляется в удобное для вас время по технологиям Ethernet, Docsis.
+            Монтажник проведёт все необходимые работы под ключ.
+        </div>
+    </ContentArea>
+
+    <ContentArea outerBackgroundColor="spbSky0">
+        <div style={{ color: '#333333'}}>
+            (spbSky0) Подключение к домашнему интернету осуществляется в удобное для вас время по технологиям Ethernet, Docsis.
+            Монтажник проведёт все необходимые работы под ключ.
+        </div>
+    </ContentArea>
+
+    <ContentArea outerBackgroundColor="spbSky1">
+        <div style={{ color: '#333333'}}>
+            (spbSky1) Подключение к домашнему интернету осуществляется в удобное для вас время по технологиям Ethernet, Docsis.
+            Монтажник проведёт все необходимые работы под ключ.
+        </div>
+    </ContentArea>
+    <ContentArea outerBackgroundColor="spbSky2">
+        <div style={{ color: '#333333'}}>
+            (spbSky2) Подключение к домашнему интернету осуществляется в удобное для вас время по технологиям Ethernet, Docsis.
             Монтажник проведёт все необходимые работы под ключ.
         </div>
     </ContentArea>
@@ -25,11 +66,11 @@ import { wrapperStyles } from './ContentArea.docz';
 
 ## Фоновый цвет внутреннего контейнера
 Фоновый цвет применяется к отцентрированному контейнеру с ограниченной шириной.
-Разница будет видна при ширине компонента больше 1440px
+Разница будет видна при ширине компонента больше 1440px.
 
 <Playground style={wrapperStyles}>
     <ContentArea innerBackgroundColor="purple">
-        <div style={{ color: 'white'}}>
+        <div style={{ color: '#ffffff'}}>
             Подключение к домашнему интернету осуществляется в удобное для вас время по технологиям Ethernet, Docsis.
             Монтажник проведёт все необходимые работы под ключ.
         </div>
@@ -38,27 +79,19 @@ import { wrapperStyles } from './ContentArea.docz';
 
 ## Отключение боковых отступов на всех разрешениях
 
-<Playground style={wrapperStyles}>
-    <ContentArea disableIndents="all" outerBackgroundColor="spbSky2">
-        Подключение к домашнему интернету осуществляется в удобное для вас время по технологиям Ethernet, Docsis.
+Разница будет видна при изменении ширины окна
+
+<Playground style={blockStyle}>
+    <ContentArea disableIndents="all" outerBackgroundColor="spbSky0">
+        Без отключения отступов. Подключение к домашнему интернету осуществляется в удобное для вас время по технологиям Ethernet, Docsis.
         Монтажник проведёт все необходимые работы под ключ.
     </ContentArea>
-</Playground>
-
-## Отключение боковых оступов на разрешении 0 - 1023
-
-<Playground style={wrapperStyles}>
-    <ContentArea disableIndents="mobile-tablet" outerBackgroundColor="spbSky2">
-        Подключение к домашнему интернету осуществляется в удобное для вас время по технологиям Ethernet, Docsis.
+    <ContentArea disableIndents="mobile-tablet" outerBackgroundColor="spbSky0">
+        Отключение боковых оступов на разрешении 0–1023px. Подключение к домашнему интернету осуществляется в удобное для вас время по технологиям Ethernet, Docsis.
         Монтажник проведёт все необходимые работы под ключ.
     </ContentArea>
-</Playground>
-
-## Отключение боковых оступов на разрешении 0 - 767
-
-<Playground style={wrapperStyles}>
-    <ContentArea disableIndents="mobile" outerBackgroundColor="spbSky2">
-        Подключение к домашнему интернету осуществляется в удобное для вас время по технологиям Ethernet, Docsis.
+    <ContentArea disableIndents="mobile" outerBackgroundColor="spbSky0">
+        Отключение боковых оступов на разрешении 0–767px. Подключение к домашнему интернету осуществляется в удобное для вас время по технологиям Ethernet, Docsis.
         Монтажник проведёт все необходимые работы под ключ.
     </ContentArea>
 </Playground>

--- a/packages/ui-core/src/components/Counter/Counter.test.tsx
+++ b/packages/ui-core/src/components/Counter/Counter.test.tsx
@@ -3,6 +3,12 @@ import { shallow, mount } from 'enzyme';
 import Counter, { ICounterProps } from './Counter';
 
 const props: ICounterProps = {
+    dataAttrs: {
+        root: { 'data-testid': 'root-test' },
+        minus: { 'data-testid': 'minus-test' },
+        plus: { 'data-testid': 'plus-test' },
+        input: { 'data-testid': 'input-test' },
+    },
     initialValue: 10,
     min: 3,
     max: 33,

--- a/packages/ui-core/src/components/Counter/Counter.tsx
+++ b/packages/ui-core/src/components/Counter/Counter.tsx
@@ -1,11 +1,18 @@
 import * as React from 'react';
-import { cnCreate } from '@megafon/ui-helpers';
+import { cnCreate, filterDataAttrs } from '@megafon/ui-helpers';
 import IconMinus from '@megafon/ui-icons/system-16-minus_16.svg';
 import IconPlus from '@megafon/ui-icons/system-16-plus_16.svg';
 import * as PropTypes from 'prop-types';
 import './Counter.less';
 
 export interface ICounterProps {
+    /** Дополнительные data атрибуты к внутренним элементам */
+    dataAttrs?: {
+        root?: Record<string, string>;
+        minus?: Record<string, string>;
+        plus?: Record<string, string>;
+        input?: Record<string, string>;
+    };
     /** Переводит компонент в контролируемое состояние */
     isControlled?: boolean;
     /** Внешнее значение для контролируемого компонента */
@@ -33,6 +40,7 @@ export interface ICounterProps {
 
 const cn = cnCreate('mfui-counter');
 const Counter: React.FC<ICounterProps> = ({
+    dataAttrs,
     isControlled = false,
     value = 0,
     initialValue,
@@ -112,8 +120,9 @@ const Counter: React.FC<ICounterProps> = ({
     );
 
     return (
-        <div className={cn({ disabled }, [className, classes.root])}>
+        <div {...filterDataAttrs(dataAttrs?.root)} className={cn({ disabled }, [className, classes.root])}>
             <button
+                {...filterDataAttrs(dataAttrs?.minus)}
                 className={cn('btn', { left: true }, classes.buttonMinus)}
                 type="button"
                 disabled={disabled || (isControlled ? value : counter) <= min}
@@ -123,6 +132,7 @@ const Counter: React.FC<ICounterProps> = ({
             </button>
             <div className={cn('input-box')}>
                 <input
+                    {...filterDataAttrs(dataAttrs?.input)}
                     className={cn('input', classes.input)}
                     value={isControlled ? value : counter}
                     onChange={handleInputChange}
@@ -131,6 +141,7 @@ const Counter: React.FC<ICounterProps> = ({
                 />
             </div>
             <button
+                {...filterDataAttrs(dataAttrs?.plus)}
                 className={cn('btn', { right: true }, classes.buttonPlus)}
                 type="button"
                 disabled={disabled || counter >= max || value >= max}
@@ -143,6 +154,12 @@ const Counter: React.FC<ICounterProps> = ({
 };
 
 Counter.propTypes = {
+    dataAttrs: PropTypes.shape({
+        root: PropTypes.objectOf(PropTypes.string.isRequired),
+        minus: PropTypes.objectOf(PropTypes.string.isRequired),
+        plus: PropTypes.objectOf(PropTypes.string.isRequired),
+        input: PropTypes.objectOf(PropTypes.string.isRequired),
+    }),
     isControlled: PropTypes.bool,
     value: PropTypes.number,
     initialValue: PropTypes.number,

--- a/packages/ui-core/src/components/Counter/__snapshots__/Counter.test.tsx.snap
+++ b/packages/ui-core/src/components/Counter/__snapshots__/Counter.test.tsx.snap
@@ -41,9 +41,11 @@ exports[`<Counter /> layout renders Counter 1`] = `
 exports[`<Counter /> layout renders Counter with "isControlled" props 1`] = `
 <div
   className="mfui-counter mfui-counter_disabled class-name root-class"
+  data-testid="root-test"
 >
   <button
     className="mfui-counter__btn mfui-counter__btn_left button-minus-class"
+    data-testid="minus-test"
     disabled={true}
     onClick={[Function]}
     type="button"
@@ -57,6 +59,7 @@ exports[`<Counter /> layout renders Counter with "isControlled" props 1`] = `
   >
     <input
       className="mfui-counter__input input-class"
+      data-testid="input-test"
       disabled={true}
       onBlur={[Function]}
       onChange={[Function]}
@@ -65,6 +68,7 @@ exports[`<Counter /> layout renders Counter with "isControlled" props 1`] = `
   </div>
   <button
     className="mfui-counter__btn mfui-counter__btn_right button-plus-class"
+    data-testid="plus-test"
     disabled={true}
     onClick={[Function]}
     type="button"
@@ -79,9 +83,11 @@ exports[`<Counter /> layout renders Counter with "isControlled" props 1`] = `
 exports[`<Counter /> layout renders Counter with props 1`] = `
 <div
   className="mfui-counter mfui-counter_disabled class-name root-class"
+  data-testid="root-test"
 >
   <button
     className="mfui-counter__btn mfui-counter__btn_left button-minus-class"
+    data-testid="minus-test"
     disabled={true}
     onClick={[Function]}
     type="button"
@@ -95,6 +101,7 @@ exports[`<Counter /> layout renders Counter with props 1`] = `
   >
     <input
       className="mfui-counter__input input-class"
+      data-testid="input-test"
       disabled={true}
       onBlur={[Function]}
       onChange={[Function]}
@@ -103,6 +110,7 @@ exports[`<Counter /> layout renders Counter with props 1`] = `
   </div>
   <button
     className="mfui-counter__btn mfui-counter__btn_right button-plus-class"
+    data-testid="plus-test"
     disabled={true}
     onClick={[Function]}
     type="button"

--- a/packages/ui-core/src/components/Logo/Logo.tsx
+++ b/packages/ui-core/src/components/Logo/Logo.tsx
@@ -20,7 +20,13 @@ export interface ILogoProps {
 }
 
 const cn = cnCreate('mfui-logo');
-const Logo: React.FC<ILogoProps> = ({ className, color, view, target, href }) => {
+const Logo: React.FC<ILogoProps> = ({
+    className,
+    color = 'green',
+    view = 'horizontal',
+    target = '_blank',
+    href = '/',
+}) => {
     const images = {
         'green-horizontal': greenHorizontalImg,
         'green-vertical': greenVerticalImg,
@@ -42,13 +48,6 @@ Logo.propTypes = {
     target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top']),
     href: PropTypes.string,
     className: PropTypes.string,
-};
-
-Logo.defaultProps = {
-    color: 'green',
-    view: 'horizontal',
-    target: '_blank',
-    href: '/',
 };
 
 export default Logo;

--- a/packages/ui-core/src/components/NavArrow/NavArrow.test.tsx
+++ b/packages/ui-core/src/components/NavArrow/NavArrow.test.tsx
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import NavArrow, { INavArrowProps, Theme, View } from './NavArrow';
 
 const props: INavArrowProps = {
+    dataAttrs: { root: { 'data-testid': 'test' } },
     className: 'class',
     theme: Theme.DARK,
     view: View.NEXT,

--- a/packages/ui-core/src/components/NavArrow/NavArrow.tsx
+++ b/packages/ui-core/src/components/NavArrow/NavArrow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import './NavArrow.less';
-import { cnCreate } from '@megafon/ui-helpers';
+import { cnCreate, filterDataAttrs } from '@megafon/ui-helpers';
 import ArrowLeft from '@megafon/ui-icons/system-24-arrow_left_24.svg';
 import ArrowRight from '@megafon/ui-icons/system-24-arrow_right_24.svg';
 import * as PropTypes from 'prop-types';
@@ -19,6 +19,9 @@ type ThemeType = typeof Theme[keyof typeof Theme];
 type ViewType = typeof View[keyof typeof View];
 
 export interface INavArrowProps {
+    dataAttrs?: {
+        root?: Record<string, string>;
+    };
     className?: string;
     theme?: ThemeType;
     view?: ViewType;
@@ -28,6 +31,7 @@ export interface INavArrowProps {
 
 const cn = cnCreate('mfui-nav-arrow');
 const NavArrow: React.FC<INavArrowProps> = ({
+    dataAttrs,
     className,
     view = View.PREV,
     theme = Theme.PURPLE,
@@ -45,13 +49,22 @@ const NavArrow: React.FC<INavArrowProps> = ({
     }, [view]);
 
     return (
-        <button type="button" className={cn({ theme }, className)} onClick={onClick} disabled={disabled}>
+        <button
+            {...filterDataAttrs(dataAttrs?.root)}
+            type="button"
+            className={cn({ theme }, className)}
+            onClick={onClick}
+            disabled={disabled}
+        >
             {renderIcon()}
         </button>
     );
 };
 
 NavArrow.propTypes = {
+    dataAttrs: PropTypes.shape({
+        root: PropTypes.objectOf(PropTypes.string.isRequired),
+    }),
     className: PropTypes.string,
     theme: PropTypes.oneOf(Object.values(Theme)),
     view: PropTypes.oneOf(Object.values(View)),

--- a/packages/ui-core/src/components/NavArrow/__snapshots__/NavArrow.test.tsx.snap
+++ b/packages/ui-core/src/components/NavArrow/__snapshots__/NavArrow.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`<NavArrow /> should render with default props 1`] = `
 exports[`<NavArrow /> should render with props 1`] = `
 <button
   className="mfui-nav-arrow mfui-nav-arrow_theme_dark class"
+  data-testid="test"
   disabled={true}
   onClick={[MockFunction]}
   type="button"

--- a/packages/ui-core/src/components/Paragraph/Paragraph.tsx
+++ b/packages/ui-core/src/components/Paragraph/Paragraph.tsx
@@ -34,7 +34,7 @@ const cn = cnCreate('mfui-paragraph');
 const Paragraph: React.FC<IParagraphProps> = ({
     size = 'regular',
     align,
-    color = COLORS.DEFAULT,
+    color = 'default',
     className,
     hasMargin = true,
     dataAttrs,

--- a/packages/ui-core/src/components/Search/Search.test.tsx
+++ b/packages/ui-core/src/components/Search/Search.test.tsx
@@ -25,6 +25,12 @@ const getCustomItems = (): SearchItem[] => {
 };
 
 const props: ISearchProps = {
+    dataAttrs: {
+        root: { 'data-testid': 'root-test' },
+        searchField: { 'data-testid': 'searchField-test' },
+        submit: { 'data-testid': 'submit-test' },
+        item: { 'data-testid': 'item-test' },
+    },
     value: 'initial value',
     placeholder: 'type to search here',
     items: [{ value: 'title' }, { value: 'title2' }, { value: 'title3' }, { value: 'title4' }],

--- a/packages/ui-core/src/components/Search/Search.tsx
+++ b/packages/ui-core/src/components/Search/Search.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cnCreate } from '@megafon/ui-helpers';
+import { cnCreate, filterDataAttrs } from '@megafon/ui-helpers';
 import SearchIcon from '@megafon/ui-icons/basic-24-search_24.svg';
 import debounce from 'lodash.debounce';
 import * as PropTypes from 'prop-types';
@@ -27,6 +27,13 @@ export type SearchItem = {
 };
 
 export interface ISearchProps {
+    /** Дополнительные data атрибуты к внутренним элементам */
+    dataAttrs?: {
+        root?: Record<string, string>;
+        searchField?: Record<string, string>;
+        submit?: Record<string, string>;
+        item?: Record<string, string>;
+    };
     /** Значение */
     value?: string;
     /** Заголовок поля */
@@ -65,6 +72,7 @@ export interface ISearchProps {
 
 const cn = cnCreate('mfui-search');
 const Search: React.FC<ISearchProps> = ({
+    dataAttrs,
     value = '',
     label,
     placeholder,
@@ -210,7 +218,7 @@ const Search: React.FC<ISearchProps> = ({
     };
 
     return (
-        <div className={cn({ open: isFocused, disabled }, [className])}>
+        <div {...filterDataAttrs(dataAttrs?.root)} className={cn({ open: isFocused, disabled }, [className])}>
             {label && (
                 <InputLabel>
                     {label}
@@ -219,6 +227,7 @@ const Search: React.FC<ISearchProps> = ({
             )}
             <div className={cn('control', { error: verification === Verification.ERROR }, [classes?.control])}>
                 <input
+                    {...filterDataAttrs(dataAttrs?.searchField)}
                     className={cn('search-field')}
                     placeholder={placeholder}
                     value={searchQuery}
@@ -232,7 +241,11 @@ const Search: React.FC<ISearchProps> = ({
                     autoComplete="off"
                 />
                 {!hideIcon && (
-                    <div className={cn('icon-box')} onClick={handleSearchSubmit}>
+                    <div
+                        {...filterDataAttrs(dataAttrs?.submit)}
+                        className={cn('icon-box')}
+                        onClick={handleSearchSubmit}
+                    >
                         <SearchIcon className={cn('icon', [classes?.icon])} />
                     </div>
                 )}
@@ -242,6 +255,7 @@ const Search: React.FC<ISearchProps> = ({
                         <div className={cn('list-inner')}>
                             {items.map(({ value: itemValue, searchView }: SearchItem, i) => (
                                 <div
+                                    {...filterDataAttrs(dataAttrs?.item, i + 1)}
                                     className={cn('list-item', { active: activeIndex === i })}
                                     onMouseDown={handleSelectSubmit(i)}
                                     onMouseEnter={handleHoverItem(i)}
@@ -272,6 +286,12 @@ const Search: React.FC<ISearchProps> = ({
 };
 
 Search.propTypes = {
+    dataAttrs: PropTypes.shape({
+        root: PropTypes.objectOf(PropTypes.string.isRequired),
+        searchField: PropTypes.objectOf(PropTypes.string.isRequired),
+        submit: PropTypes.objectOf(PropTypes.string.isRequired),
+        item: PropTypes.objectOf(PropTypes.string.isRequired),
+    }),
     value: PropTypes.string,
     label: PropTypes.string,
     placeholder: PropTypes.string,

--- a/packages/ui-core/src/components/Search/__snapshots__/Search.test.tsx.snap
+++ b/packages/ui-core/src/components/Search/__snapshots__/Search.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`<Search /> snapshots renders Search with all props correctly 1`] = `
 <div
   className="mfui-search test"
+  data-testid="root-test"
 >
   <div
     className="mfui-search__control"
@@ -10,6 +11,7 @@ exports[`<Search /> snapshots renders Search with all props correctly 1`] = `
     <input
       autoComplete="off"
       className="mfui-search__search-field"
+      data-testid="searchField-test"
       onBlur={[Function]}
       onChange={[Function]}
       onClick={[Function]}
@@ -21,6 +23,7 @@ exports[`<Search /> snapshots renders Search with all props correctly 1`] = `
     />
     <div
       className="mfui-search__icon-box"
+      data-testid="submit-test"
       onClick={[Function]}
     >
       <test-file-stub
@@ -35,6 +38,7 @@ exports[`<Search /> snapshots renders Search with all props correctly 1`] = `
       >
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[1]"
           key="0"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -47,6 +51,7 @@ exports[`<Search /> snapshots renders Search with all props correctly 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[2]"
           key="1"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -59,6 +64,7 @@ exports[`<Search /> snapshots renders Search with all props correctly 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[3]"
           key="2"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -71,6 +77,7 @@ exports[`<Search /> snapshots renders Search with all props correctly 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[4]"
           key="3"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -90,6 +97,7 @@ exports[`<Search /> snapshots renders Search with all props correctly 1`] = `
 exports[`<Search /> snapshots renders Search with classes 1`] = `
 <div
   className="mfui-search test"
+  data-testid="root-test"
 >
   <div
     className="mfui-search__control control-outer"
@@ -97,6 +105,7 @@ exports[`<Search /> snapshots renders Search with classes 1`] = `
     <input
       autoComplete="off"
       className="mfui-search__search-field"
+      data-testid="searchField-test"
       onBlur={[Function]}
       onChange={[Function]}
       onClick={[Function]}
@@ -108,6 +117,7 @@ exports[`<Search /> snapshots renders Search with classes 1`] = `
     />
     <div
       className="mfui-search__icon-box"
+      data-testid="submit-test"
       onClick={[Function]}
     >
       <test-file-stub
@@ -122,6 +132,7 @@ exports[`<Search /> snapshots renders Search with classes 1`] = `
       >
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[1]"
           key="0"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -134,6 +145,7 @@ exports[`<Search /> snapshots renders Search with classes 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[2]"
           key="1"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -146,6 +158,7 @@ exports[`<Search /> snapshots renders Search with classes 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[3]"
           key="2"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -158,6 +171,7 @@ exports[`<Search /> snapshots renders Search with classes 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[4]"
           key="3"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -177,6 +191,7 @@ exports[`<Search /> snapshots renders Search with classes 1`] = `
 exports[`<Search /> snapshots renders Search without icon 1`] = `
 <div
   className="mfui-search test"
+  data-testid="root-test"
 >
   <div
     className="mfui-search__control"
@@ -184,6 +199,7 @@ exports[`<Search /> snapshots renders Search without icon 1`] = `
     <input
       autoComplete="off"
       className="mfui-search__search-field"
+      data-testid="searchField-test"
       onBlur={[Function]}
       onChange={[Function]}
       onClick={[Function]}
@@ -201,6 +217,7 @@ exports[`<Search /> snapshots renders Search without icon 1`] = `
       >
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[1]"
           key="0"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -213,6 +230,7 @@ exports[`<Search /> snapshots renders Search without icon 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[2]"
           key="1"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -225,6 +243,7 @@ exports[`<Search /> snapshots renders Search without icon 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[3]"
           key="2"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -237,6 +256,7 @@ exports[`<Search /> snapshots renders Search without icon 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[4]"
           key="3"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -286,6 +306,7 @@ exports[`<Search /> snapshots renders Search without props correctly 1`] = `
 exports[`<Search /> snapshots renders with customItemsProps 1`] = `
 <div
   className="mfui-search test"
+  data-testid="root-test"
 >
   <div
     className="mfui-search__control"
@@ -293,6 +314,7 @@ exports[`<Search /> snapshots renders with customItemsProps 1`] = `
     <input
       autoComplete="off"
       className="mfui-search__search-field"
+      data-testid="searchField-test"
       onBlur={[Function]}
       onChange={[Function]}
       onClick={[Function]}
@@ -304,6 +326,7 @@ exports[`<Search /> snapshots renders with customItemsProps 1`] = `
     />
     <div
       className="mfui-search__icon-box"
+      data-testid="submit-test"
       onClick={[Function]}
     >
       <test-file-stub
@@ -318,6 +341,7 @@ exports[`<Search /> snapshots renders with customItemsProps 1`] = `
       >
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[1]"
           key="0"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -345,6 +369,7 @@ exports[`<Search /> snapshots renders with customItemsProps 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[2]"
           key="1"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -372,6 +397,7 @@ exports[`<Search /> snapshots renders with customItemsProps 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[3]"
           key="2"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -399,6 +425,7 @@ exports[`<Search /> snapshots renders with customItemsProps 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[4]"
           key="3"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -426,6 +453,7 @@ exports[`<Search /> snapshots renders with customItemsProps 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[5]"
           key="4"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -460,6 +488,7 @@ exports[`<Search /> snapshots renders with customItemsProps 1`] = `
 exports[`<Search /> snapshots renders with label and required props 1`] = `
 <div
   className="mfui-search test"
+  data-testid="root-test"
 >
   <InputLabel>
     test label
@@ -475,6 +504,7 @@ exports[`<Search /> snapshots renders with label and required props 1`] = `
     <input
       autoComplete="off"
       className="mfui-search__search-field"
+      data-testid="searchField-test"
       onBlur={[Function]}
       onChange={[Function]}
       onClick={[Function]}
@@ -486,6 +516,7 @@ exports[`<Search /> snapshots renders with label and required props 1`] = `
     />
     <div
       className="mfui-search__icon-box"
+      data-testid="submit-test"
       onClick={[Function]}
     >
       <test-file-stub
@@ -500,6 +531,7 @@ exports[`<Search /> snapshots renders with label and required props 1`] = `
       >
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[1]"
           key="0"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -512,6 +544,7 @@ exports[`<Search /> snapshots renders with label and required props 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[2]"
           key="1"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -524,6 +557,7 @@ exports[`<Search /> snapshots renders with label and required props 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[3]"
           key="2"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -536,6 +570,7 @@ exports[`<Search /> snapshots renders with label and required props 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[4]"
           key="3"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -555,6 +590,7 @@ exports[`<Search /> snapshots renders with label and required props 1`] = `
 exports[`<Search /> snapshots renders with noticeText and verification="error" 1`] = `
 <div
   className="mfui-search test"
+  data-testid="root-test"
 >
   <div
     className="mfui-search__control mfui-search__control_error"
@@ -562,6 +598,7 @@ exports[`<Search /> snapshots renders with noticeText and verification="error" 1
     <input
       autoComplete="off"
       className="mfui-search__search-field"
+      data-testid="searchField-test"
       onBlur={[Function]}
       onChange={[Function]}
       onClick={[Function]}
@@ -573,6 +610,7 @@ exports[`<Search /> snapshots renders with noticeText and verification="error" 1
     />
     <div
       className="mfui-search__icon-box"
+      data-testid="submit-test"
       onClick={[Function]}
     >
       <test-file-stub
@@ -587,6 +625,7 @@ exports[`<Search /> snapshots renders with noticeText and verification="error" 1
       >
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[1]"
           key="0"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -599,6 +638,7 @@ exports[`<Search /> snapshots renders with noticeText and verification="error" 1
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[2]"
           key="1"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -611,6 +651,7 @@ exports[`<Search /> snapshots renders with noticeText and verification="error" 1
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[3]"
           key="2"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -623,6 +664,7 @@ exports[`<Search /> snapshots renders with noticeText and verification="error" 1
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[4]"
           key="3"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -647,6 +689,7 @@ exports[`<Search /> snapshots renders with noticeText and verification="error" 1
 exports[`<Search /> snapshots renders with noticeText and verification="valid" 1`] = `
 <div
   className="mfui-search test"
+  data-testid="root-test"
 >
   <div
     className="mfui-search__control"
@@ -654,6 +697,7 @@ exports[`<Search /> snapshots renders with noticeText and verification="valid" 1
     <input
       autoComplete="off"
       className="mfui-search__search-field"
+      data-testid="searchField-test"
       onBlur={[Function]}
       onChange={[Function]}
       onClick={[Function]}
@@ -665,6 +709,7 @@ exports[`<Search /> snapshots renders with noticeText and verification="valid" 1
     />
     <div
       className="mfui-search__icon-box"
+      data-testid="submit-test"
       onClick={[Function]}
     >
       <test-file-stub
@@ -679,6 +724,7 @@ exports[`<Search /> snapshots renders with noticeText and verification="valid" 1
       >
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[1]"
           key="0"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -691,6 +737,7 @@ exports[`<Search /> snapshots renders with noticeText and verification="valid" 1
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[2]"
           key="1"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -703,6 +750,7 @@ exports[`<Search /> snapshots renders with noticeText and verification="valid" 1
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[3]"
           key="2"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -715,6 +763,7 @@ exports[`<Search /> snapshots renders with noticeText and verification="valid" 1
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[4]"
           key="3"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -739,6 +788,7 @@ exports[`<Search /> snapshots renders with noticeText and verification="valid" 1
 exports[`<Search /> typing highlighted text 1`] = `
 <div
   className="mfui-search test"
+  data-testid="root-test"
 >
   <div
     className="mfui-search__control"
@@ -746,6 +796,7 @@ exports[`<Search /> typing highlighted text 1`] = `
     <input
       autoComplete="off"
       className="mfui-search__search-field"
+      data-testid="searchField-test"
       onBlur={[Function]}
       onChange={[Function]}
       onClick={[Function]}
@@ -757,6 +808,7 @@ exports[`<Search /> typing highlighted text 1`] = `
     />
     <div
       className="mfui-search__icon-box"
+      data-testid="submit-test"
       onClick={[Function]}
     >
       <test-file-stub
@@ -771,6 +823,7 @@ exports[`<Search /> typing highlighted text 1`] = `
       >
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[1]"
           key="0"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -783,6 +836,7 @@ exports[`<Search /> typing highlighted text 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[2]"
           key="1"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -799,6 +853,7 @@ exports[`<Search /> typing highlighted text 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[3]"
           key="2"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}
@@ -811,6 +866,7 @@ exports[`<Search /> typing highlighted text 1`] = `
         </div>
         <div
           className="mfui-search__list-item"
+          data-testid="item-test[4]"
           key="3"
           onMouseDown={[Function]}
           onMouseEnter={[Function]}

--- a/packages/ui-core/src/components/Switcher/Switcher.test.tsx
+++ b/packages/ui-core/src/components/Switcher/Switcher.test.tsx
@@ -9,8 +9,10 @@ describe('<Switcher />', () => {
             expect(wrapper).toMatchSnapshot();
         });
 
-        it('should render switcher with external className', () => {
-            const wrapper = shallow(<Switcher className="external-class-name" />);
+        it('should render switcher with external className and data-attributes', () => {
+            const wrapper = shallow(
+                <Switcher className="external-class-name" dataAttrs={{ root: { 'data-testid': 'root-test' } }} />,
+            );
             expect(wrapper).toMatchSnapshot();
         });
 

--- a/packages/ui-core/src/components/Switcher/Switcher.tsx
+++ b/packages/ui-core/src/components/Switcher/Switcher.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
-import { cnCreate, detectTouch } from '@megafon/ui-helpers';
+import { cnCreate, detectTouch, filterDataAttrs } from '@megafon/ui-helpers';
+import * as PropTypes from 'prop-types';
 import './Switcher.less';
 
 export interface ISwitcherProps {
+    /** Дополнительные data атрибуты к внутренним элементам */
+    dataAttrs?: {
+        root?: Record<string, string>;
+    };
     /** Дополнительный класс корневого элемента */
     className?: string;
     /** Управление состоянием вкл/выкл компонента */
@@ -14,9 +19,7 @@ export interface ISwitcherProps {
 }
 
 const cn = cnCreate('mfui-switcher');
-const Switcher: React.FC<ISwitcherProps> = props => {
-    const { className, checked = false, disabled = false, onChange } = props;
-
+const Switcher: React.FC<ISwitcherProps> = ({ dataAttrs, className, checked = false, disabled = false, onChange }) => {
     const isTouch: boolean = detectTouch();
 
     const handleChange = (e: React.MouseEvent<HTMLDivElement>): void => {
@@ -29,6 +32,7 @@ const Switcher: React.FC<ISwitcherProps> = props => {
 
     return (
         <div
+            {...filterDataAttrs(dataAttrs?.root)}
             className={cn(
                 {
                     checked,
@@ -42,6 +46,16 @@ const Switcher: React.FC<ISwitcherProps> = props => {
             <div className={cn('pointer')} />
         </div>
     );
+};
+
+Switcher.propTypes = {
+    dataAttrs: PropTypes.shape({
+        root: PropTypes.objectOf(PropTypes.string.isRequired),
+    }),
+    className: PropTypes.string,
+    checked: PropTypes.bool,
+    disabled: PropTypes.bool,
+    onChange: PropTypes.func,
 };
 
 export default Switcher;

--- a/packages/ui-core/src/components/Switcher/__snapshots__/Switcher.test.tsx.snap
+++ b/packages/ui-core/src/components/Switcher/__snapshots__/Switcher.test.tsx.snap
@@ -44,9 +44,10 @@ exports[`<Switcher /> layout should render switcher with default props 1`] = `
 </div>
 `;
 
-exports[`<Switcher /> layout should render switcher with external className 1`] = `
+exports[`<Switcher /> layout should render switcher with external className and data-attributes 1`] = `
 <div
   className="mfui-switcher mfui-switcher_no-touch external-class-name"
+  data-testid="root-test"
   onClick={[Function]}
 >
   <div

--- a/packages/ui-core/src/components/Tabs/Tabs.less
+++ b/packages/ui-core/src/components/Tabs/Tabs.less
@@ -144,7 +144,7 @@
         height: 16px;
         border-radius: 50%;
 
-        background-color: var(--content);
+        background-color: var(--stcBlack);
         transform: translateY(-50%);
         cursor: pointer;
 

--- a/packages/ui-core/src/components/TextLink/TextLink.tsx
+++ b/packages/ui-core/src/components/TextLink/TextLink.tsx
@@ -16,9 +16,9 @@ export interface ITextLinkProps extends ILinkProps {
 
 const cn = cnCreate('mfui-text-link');
 const TextLink: React.FC<ITextLinkProps> = ({
-    underlineVisibility,
-    underlineStyle,
-    color,
+    underlineVisibility = 'hover',
+    underlineStyle = 'solid',
+    color = 'blue',
     className,
     target,
     href,
@@ -62,12 +62,6 @@ TextLink.propTypes = {
         PropTypes.string,
         PropTypes.node,
     ]),
-};
-
-TextLink.defaultProps = {
-    underlineVisibility: 'hover',
-    underlineStyle: 'solid',
-    color: 'blue',
 };
 
 export default TextLink;

--- a/packages/ui-shared/src/components/AccordionBox/AccordionBox.tsx
+++ b/packages/ui-shared/src/components/AccordionBox/AccordionBox.tsx
@@ -8,6 +8,11 @@ export interface IAccordionBox {
     /** Дополнительные data атрибуты к внутренним элементам */
     dataAttrs?: {
         root?: Record<string, string>;
+        header?: Record<string, string>;
+        collapse?: Record<string, string>;
+        titleWrap?: Record<string, string>;
+        arrowUp?: Record<string, string>;
+        arrowDown?: Record<string, string>;
     };
     /** Ссылка на корневой элемент */
     rootRef?: React.Ref<HTMLDivElement>;
@@ -53,6 +58,11 @@ const AccordionBox: React.FC<IAccordionBox> = ({ hCenterAlignWide = false, isFul
 AccordionBox.propTypes = {
     dataAttrs: PropTypes.shape({
         root: PropTypes.objectOf(PropTypes.string.isRequired),
+        header: PropTypes.objectOf(PropTypes.string.isRequired),
+        collapse: PropTypes.objectOf(PropTypes.string.isRequired),
+        titleWrap: PropTypes.objectOf(PropTypes.string.isRequired),
+        arrowUp: PropTypes.objectOf(PropTypes.string.isRequired),
+        arrowDown: PropTypes.objectOf(PropTypes.string.isRequired),
     }),
     rootRef: PropTypes.oneOfType([
         PropTypes.func,

--- a/packages/ui-shared/src/components/BenefitsIcons/BenefitsIcons.tsx
+++ b/packages/ui-shared/src/components/BenefitsIcons/BenefitsIcons.tsx
@@ -134,7 +134,7 @@ const getMultiColumnConfig = (iconPosition: IconPosition, count: number, index: 
 const cn = cnCreate('mfui-benefits-icons');
 const BenefitsIcons: React.FC<IBenefitsIcons> = ({
     rootRef,
-    iconPosition = IconPositionEnum.LEFT_TOP,
+    iconPosition = 'left-top',
     inOneColumn = false,
     items,
     className,

--- a/packages/ui-shared/src/components/Breadcrumbs/Breadcrumbs.less
+++ b/packages/ui-shared/src/components/Breadcrumbs/Breadcrumbs.less
@@ -36,12 +36,12 @@
         position: relative;
 
         margin-right: 10px;
-        padding-left: 22px;
+        padding-left: 26px;
 
         &:before {
             content: '→';
             position: absolute;
-            top: -2px;
+            top: -1px;
             left: 0;
         }
     }

--- a/packages/ui-shared/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/ui-shared/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -27,6 +27,7 @@ describe('Breadcrumbs', () => {
     it('should render with optional props', () => {
         const wrapper = shallow(
             <Breadcrumbs
+                dataAttrs={{ root: { 'data-testid': 'root-test' }, link: { 'data-testid': 'link-test' } }}
                 items={items}
                 className="custom-class-name"
                 classes={{ item: 'item-custom-class-name' }}

--- a/packages/ui-shared/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/ui-shared/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TextLink } from '@megafon/ui-core';
-import { cnCreate } from '@megafon/ui-helpers';
+import { cnCreate, filterDataAttrs } from '@megafon/ui-helpers';
 import PropTypes from 'prop-types';
 import './Breadcrumbs.less';
 
@@ -22,6 +22,10 @@ export const TextColor = {
 type TextColorType = typeof TextColor[keyof typeof TextColor];
 
 export type Props = {
+    dataAttrs?: {
+        root?: Record<string, string>;
+        link?: Record<string, string>;
+    };
     className?: string;
     classes?: { item?: string };
     items: ItemType[];
@@ -37,8 +41,8 @@ function isJSXElement(item: ItemType): item is JSX.Element {
 }
 
 const cn = cnCreate('mfui-breadcrumbs');
-const Breadcrumbs: React.FC<Props> = ({ items, color = 'black', className, classes = {} }) => (
-    <div className={cn({ color }, className)}>
+const Breadcrumbs: React.FC<Props> = ({ items, color = 'black', className, classes = {}, dataAttrs }) => (
+    <div {...filterDataAttrs(dataAttrs?.root)} className={cn({ color }, className)}>
         {items.map((item: ItemType, i: number): JSX.Element | null => {
             if (isJSXElement(item)) {
                 return (
@@ -52,7 +56,13 @@ const Breadcrumbs: React.FC<Props> = ({ items, color = 'black', className, class
                 return (
                     <div className={cn('item', classes.item)} key={item.component ? i : item.title}>
                         {item.component || (
-                            <TextLink href={item.href} color={color}>
+                            <TextLink
+                                href={item.href}
+                                color={color}
+                                dataAttrs={{
+                                    root: dataAttrs?.link ? { ...filterDataAttrs(dataAttrs?.link, i + 1) } : undefined,
+                                }}
+                            >
                                 {item.title}
                             </TextLink>
                         )}
@@ -66,6 +76,10 @@ const Breadcrumbs: React.FC<Props> = ({ items, color = 'black', className, class
 );
 
 Breadcrumbs.propTypes = {
+    dataAttrs: PropTypes.shape({
+        root: PropTypes.objectOf(PropTypes.string.isRequired),
+        link: PropTypes.objectOf(PropTypes.string.isRequired),
+    }),
     className: PropTypes.string,
     classes: PropTypes.shape({
         item: PropTypes.string,

--- a/packages/ui-shared/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/ui-shared/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -4,11 +4,14 @@ import { cnCreate } from '@megafon/ui-helpers';
 import PropTypes from 'prop-types';
 import './Breadcrumbs.less';
 
-type ItemType = {
-    component?: React.ReactElement;
+type ItemObjectType = {
     title?: string;
     href?: string;
+    /* @deprecated */
+    component?: React.ReactElement;
 };
+
+type ItemType = JSX.Element | ItemObjectType;
 
 export const TextColor = {
     DEFAULT: 'default',
@@ -25,20 +28,40 @@ export type Props = {
     color?: TextColorType;
 };
 
+function isObjectElement(item: ItemType): item is ItemObjectType {
+    return !React.isValidElement(item);
+}
+
+function isJSXElement(item: ItemType): item is JSX.Element {
+    return React.isValidElement(item);
+}
+
 const cn = cnCreate('mfui-breadcrumbs');
 const Breadcrumbs: React.FC<Props> = ({ items, color = 'black', className, classes = {} }) => (
     <div className={cn({ color }, className)}>
-        {items.map(({ component, title, href }) => (
-            <div className={cn('item', classes.item)} key={title}>
-                {component}
+        {items.map((item: ItemType, i: number): JSX.Element | null => {
+            if (isJSXElement(item)) {
+                return (
+                    <div className={cn('item', classes.item)} key={i}>
+                        {item}
+                    </div>
+                );
+            }
 
-                {!component && (
-                    <TextLink href={href} color={color}>
-                        {component || title}
-                    </TextLink>
-                )}
-            </div>
-        ))}
+            if (isObjectElement(item)) {
+                return (
+                    <div className={cn('item', classes.item)} key={item.component ? i : item.title}>
+                        {item.component || (
+                            <TextLink href={item.href} color={color}>
+                                {item.title}
+                            </TextLink>
+                        )}
+                    </div>
+                );
+            }
+
+            return null;
+        })}
     </div>
 );
 
@@ -47,12 +70,17 @@ Breadcrumbs.propTypes = {
     classes: PropTypes.shape({
         item: PropTypes.string,
     }),
-    items: PropTypes.arrayOf(
-        PropTypes.shape({
-            title: PropTypes.string.isRequired,
-            href: PropTypes.string,
-        }).isRequired,
-    ).isRequired,
+    items: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.element.isRequired),
+        PropTypes.arrayOf(
+            PropTypes.shape({
+                title: PropTypes.string,
+                href: PropTypes.string,
+                /* @deprecated */
+                component: PropTypes.element,
+            }).isRequired,
+        ),
+    ]).isRequired,
     color: PropTypes.oneOf(Object.values(TextColor)),
 };
 

--- a/packages/ui-shared/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/packages/ui-shared/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -11,8 +11,6 @@ exports[`Breadcrumbs should render component 1`] = `
     <TextLink
       color="black"
       href="#"
-      underlineStyle="solid"
-      underlineVisibility="hover"
     >
       МегаФон
     </TextLink>
@@ -24,8 +22,6 @@ exports[`Breadcrumbs should render component 1`] = `
     <TextLink
       color="black"
       href="#"
-      underlineStyle="solid"
-      underlineVisibility="hover"
     >
       Мобильная связь
     </TextLink>
@@ -37,8 +33,6 @@ exports[`Breadcrumbs should render component 1`] = `
     <TextLink
       color="black"
       href="#"
-      underlineStyle="solid"
-      underlineVisibility="hover"
     >
       Тарифы
     </TextLink>
@@ -57,8 +51,6 @@ exports[`Breadcrumbs should render with optional props 1`] = `
     <TextLink
       color="white"
       href="#"
-      underlineStyle="solid"
-      underlineVisibility="hover"
     >
       МегаФон
     </TextLink>
@@ -70,8 +62,6 @@ exports[`Breadcrumbs should render with optional props 1`] = `
     <TextLink
       color="white"
       href="#"
-      underlineStyle="solid"
-      underlineVisibility="hover"
     >
       Мобильная связь
     </TextLink>
@@ -83,8 +73,6 @@ exports[`Breadcrumbs should render with optional props 1`] = `
     <TextLink
       color="white"
       href="#"
-      underlineStyle="solid"
-      underlineVisibility="hover"
     >
       Тарифы
     </TextLink>

--- a/packages/ui-shared/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/packages/ui-shared/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -10,6 +10,11 @@ exports[`Breadcrumbs should render component 1`] = `
   >
     <TextLink
       color="black"
+      dataAttrs={
+        Object {
+          "root": undefined,
+        }
+      }
       href="#"
     >
       МегаФон
@@ -21,6 +26,11 @@ exports[`Breadcrumbs should render component 1`] = `
   >
     <TextLink
       color="black"
+      dataAttrs={
+        Object {
+          "root": undefined,
+        }
+      }
       href="#"
     >
       Мобильная связь
@@ -32,6 +42,11 @@ exports[`Breadcrumbs should render component 1`] = `
   >
     <TextLink
       color="black"
+      dataAttrs={
+        Object {
+          "root": undefined,
+        }
+      }
       href="#"
     >
       Тарифы
@@ -43,6 +58,7 @@ exports[`Breadcrumbs should render component 1`] = `
 exports[`Breadcrumbs should render with optional props 1`] = `
 <div
   className="mfui-breadcrumbs mfui-breadcrumbs_color_white custom-class-name"
+  data-testid="root-test"
 >
   <div
     className="mfui-breadcrumbs__item item-custom-class-name"
@@ -50,6 +66,13 @@ exports[`Breadcrumbs should render with optional props 1`] = `
   >
     <TextLink
       color="white"
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "link-test[1]",
+          },
+        }
+      }
       href="#"
     >
       МегаФон
@@ -61,6 +84,13 @@ exports[`Breadcrumbs should render with optional props 1`] = `
   >
     <TextLink
       color="white"
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "link-test[2]",
+          },
+        }
+      }
       href="#"
     >
       Мобильная связь
@@ -72,6 +102,13 @@ exports[`Breadcrumbs should render with optional props 1`] = `
   >
     <TextLink
       color="white"
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "link-test[3]",
+          },
+        }
+      }
       href="#"
     >
       Тарифы

--- a/packages/ui-shared/src/components/Breadcrumbs/doc/Breadcrumbs.example.mdx
+++ b/packages/ui-shared/src/components/Breadcrumbs/doc/Breadcrumbs.example.mdx
@@ -1,10 +1,26 @@
 import { Playground } from 'docz';
 import Breadcrumbs from '../Breadcrumbs';
 
+## Базовое использование
+
+Каждый элемент содержит свойства `title` и `href`, которые используются для создания ссылки с помощью компонента `TextLink` из `@megafon/ui-core`
+
 <Playground>
     <Breadcrumbs items={[
         { title: 'Главная', href: 'www.megafon.ru' },
         { title: 'Каталог услуг', href: 'www.megafon.ru' },
         { title: 'Тарифы' },
+    ]} />
+</Playground>
+
+## Использование с помощью массива компонентов
+
+Каждый элемент является самостоятельным компонентом
+
+<Playground>
+    <Breadcrumbs items={[
+        <a href="www.megafon.ru">Главная</a>,
+        <a href="www.megafon.ru">Каталог услуг</a>,
+        <span>Тарифы</span>,
     ]} />
 </Playground>

--- a/packages/ui-shared/src/components/Breadcrumbs/doc/Breadcrumbs.mdx
+++ b/packages/ui-shared/src/components/Breadcrumbs/doc/Breadcrumbs.mdx
@@ -9,8 +9,6 @@ import Props from './Breadcrumbs.props.mdx';
 
 # Breadcrumbs
 
-Компонент **Breadcrumbs** — хлебные крошки
-
 <CopyToClipboardBox text="import { Breadcrumbs } from '@megafon/ui-shared';" />
 
 <DoczTabs>

--- a/packages/ui-shared/src/components/ButtonBanner/ButtonBanner.test.tsx
+++ b/packages/ui-shared/src/components/ButtonBanner/ButtonBanner.test.tsx
@@ -12,7 +12,10 @@ const props: IButtonBannerProps = {
     ...requiredProps,
     dataAttrs: {
         root: {
-            'data-root': 'value',
+            'data-testid': 'value',
+        },
+        button: {
+            'data-testid': 'button-test',
         },
     },
     className: 'className',

--- a/packages/ui-shared/src/components/ButtonBanner/ButtonBanner.tsx
+++ b/packages/ui-shared/src/components/ButtonBanner/ButtonBanner.tsx
@@ -26,6 +26,7 @@ export interface IButtonBannerProps {
     /** Дополнительные data атрибуты к внутренним элементам */
     dataAttrs?: {
         root?: Record<string, string>;
+        button?: Record<string, string>;
     };
     /** Дополнительный css класс для корневого элемента */
     className?: string;
@@ -79,6 +80,7 @@ const ButtonBanner: React.FC<IButtonBannerProps> = ({
 }) => {
     const buttonElem = (
         <Button
+            dataAttrs={{ root: dataAttrs?.button }}
             className={cn('button', [classes.button])}
             href={buttonUrl}
             target={buttonTarget}
@@ -119,6 +121,7 @@ const ButtonBanner: React.FC<IButtonBannerProps> = ({
 ButtonBanner.propTypes = {
     dataAttrs: PropTypes.shape({
         root: PropTypes.objectOf(PropTypes.string.isRequired),
+        button: PropTypes.objectOf(PropTypes.string.isRequired),
     }),
     className: PropTypes.string,
     classes: PropTypes.shape({

--- a/packages/ui-shared/src/components/ButtonBanner/__snapshots__/ButtonBanner.test.tsx.snap
+++ b/packages/ui-shared/src/components/ButtonBanner/__snapshots__/ButtonBanner.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<ButtonBanner /> should render with props 1`] = `
 <div
   className="mfui-button-banner mfui-button-banner_image mfui-button-banner_scaling_contain className rootClass"
-  data-root="value"
+  data-testid="value"
 >
   <Grid
     guttersLeft="medium"
@@ -31,6 +31,13 @@ exports[`<ButtonBanner /> should render with props 1`] = `
         </div>
         <Button
           className="mfui-button-banner__button buttonClass"
+          dataAttrs={
+            Object {
+              "root": Object {
+                "data-testid": "button-test",
+              },
+            }
+          }
           download={true}
           href="#"
           target="_blank"
@@ -96,6 +103,11 @@ exports[`<ButtonBanner /> should render with required props 1`] = `
       >
         <Button
           className="mfui-button-banner__button"
+          dataAttrs={
+            Object {
+              "root": undefined,
+            }
+          }
           target="_self"
           theme="green"
         >

--- a/packages/ui-shared/src/components/ButtonLinkBox/ButtonLinkBox.test.tsx
+++ b/packages/ui-shared/src/components/ButtonLinkBox/ButtonLinkBox.test.tsx
@@ -11,7 +11,13 @@ const props: IButtonLinkBoxProps = {
     },
     dataAttrs: {
         root: {
-            'data-root': 'value',
+            'data-testid': 'root-test',
+        },
+        link: {
+            'data-testid': 'link-test',
+        },
+        button: {
+            'data-testid': 'button-test',
         },
     },
     buttonTitle: 'button title',

--- a/packages/ui-shared/src/components/ButtonLinkBox/ButtonLinkBox.tsx
+++ b/packages/ui-shared/src/components/ButtonLinkBox/ButtonLinkBox.tsx
@@ -8,6 +8,8 @@ export interface IButtonLinkBoxProps {
     /** Дополнительные data атрибуты к внутренним элементам */
     dataAttrs?: {
         root?: Record<string, string>;
+        link?: Record<string, string>;
+        button?: Record<string, string>;
     };
     /** Дополнительный класс корневого элемента */
     className?: string;
@@ -72,6 +74,7 @@ const ButtonLinkBox: React.FC<IButtonLinkBoxProps> = ({
         {buttonTitle && (
             <div className={cn('row')}>
                 <Button
+                    dataAttrs={{ root: dataAttrs?.button }}
                     className={classes.button}
                     href={buttonUrl}
                     theme={buttonColor}
@@ -86,6 +89,7 @@ const ButtonLinkBox: React.FC<IButtonLinkBoxProps> = ({
         {linkTitle && (
             <div className={cn('row')}>
                 <TextLink
+                    dataAttrs={{ root: dataAttrs?.link }}
                     className={classes.link}
                     href={linkUrl}
                     download={linkDownload}
@@ -103,6 +107,8 @@ const ButtonLinkBox: React.FC<IButtonLinkBoxProps> = ({
 ButtonLinkBox.propTypes = {
     dataAttrs: PropTypes.shape({
         root: PropTypes.objectOf(PropTypes.string.isRequired),
+        link: PropTypes.objectOf(PropTypes.string.isRequired),
+        button: PropTypes.objectOf(PropTypes.string.isRequired),
     }),
     className: PropTypes.string,
     classes: PropTypes.shape({

--- a/packages/ui-shared/src/components/ButtonLinkBox/__snapshots__/ButtonLinkBox.test.tsx.snap
+++ b/packages/ui-shared/src/components/ButtonLinkBox/__snapshots__/ButtonLinkBox.test.tsx.snap
@@ -22,10 +22,8 @@ exports[`<ButtonLinkBox /> renders ButtonLinkBox 1`] = `
   >
     <TextLink
       className="link-class"
-      color="blue"
       href="link-url"
       target="_blank"
-      underlineStyle="solid"
       underlineVisibility="always"
     >
       link title
@@ -57,11 +55,9 @@ exports[`<ButtonLinkBox /> renders ButtonLinkBox with download links 1`] = `
   >
     <TextLink
       className="link-class"
-      color="blue"
       download={true}
       href="link-url"
       target="_blank"
-      underlineStyle="solid"
       underlineVisibility="always"
     >
       link title
@@ -80,10 +76,8 @@ exports[`<ButtonLinkBox /> renders ButtonLinkBox without button 1`] = `
   >
     <TextLink
       className="link-class"
-      color="blue"
       href="link-url"
       target="_blank"
-      underlineStyle="solid"
       underlineVisibility="always"
     >
       link title

--- a/packages/ui-shared/src/components/ButtonLinkBox/__snapshots__/ButtonLinkBox.test.tsx.snap
+++ b/packages/ui-shared/src/components/ButtonLinkBox/__snapshots__/ButtonLinkBox.test.tsx.snap
@@ -3,13 +3,20 @@
 exports[`<ButtonLinkBox /> renders ButtonLinkBox 1`] = `
 <div
   className="mfui-button-link-box mfui-button-link-box_h-align_center custom-class root-class"
-  data-root="value"
+  data-testid="root-test"
 >
   <div
     className="mfui-button-link-box__row"
   >
     <Button
       className="button-class"
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "button-test",
+          },
+        }
+      }
       href="button-url"
       target="_self"
       theme="purple"
@@ -22,6 +29,13 @@ exports[`<ButtonLinkBox /> renders ButtonLinkBox 1`] = `
   >
     <TextLink
       className="link-class"
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "link-test",
+          },
+        }
+      }
       href="link-url"
       target="_blank"
       underlineVisibility="always"
@@ -35,13 +49,20 @@ exports[`<ButtonLinkBox /> renders ButtonLinkBox 1`] = `
 exports[`<ButtonLinkBox /> renders ButtonLinkBox with download links 1`] = `
 <div
   className="mfui-button-link-box mfui-button-link-box_h-align_center custom-class root-class"
-  data-root="value"
+  data-testid="root-test"
 >
   <div
     className="mfui-button-link-box__row"
   >
     <Button
       className="button-class"
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "button-test",
+          },
+        }
+      }
       download={true}
       href="button-url"
       target="_self"
@@ -55,6 +76,13 @@ exports[`<ButtonLinkBox /> renders ButtonLinkBox with download links 1`] = `
   >
     <TextLink
       className="link-class"
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "link-test",
+          },
+        }
+      }
       download={true}
       href="link-url"
       target="_blank"
@@ -69,13 +97,20 @@ exports[`<ButtonLinkBox /> renders ButtonLinkBox with download links 1`] = `
 exports[`<ButtonLinkBox /> renders ButtonLinkBox without button 1`] = `
 <div
   className="mfui-button-link-box mfui-button-link-box_h-align_center custom-class root-class"
-  data-root="value"
+  data-testid="root-test"
 >
   <div
     className="mfui-button-link-box__row"
   >
     <TextLink
       className="link-class"
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "link-test",
+          },
+        }
+      }
       href="link-url"
       target="_blank"
       underlineVisibility="always"
@@ -89,13 +124,20 @@ exports[`<ButtonLinkBox /> renders ButtonLinkBox without button 1`] = `
 exports[`<ButtonLinkBox /> renders ButtonLinkBox without link 1`] = `
 <div
   className="mfui-button-link-box mfui-button-link-box_h-align_center custom-class root-class"
-  data-root="value"
+  data-testid="root-test"
 >
   <div
     className="mfui-button-link-box__row"
   >
     <Button
       className="button-class"
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "button-test",
+          },
+        }
+      }
       href="button-url"
       target="_self"
       theme="purple"

--- a/packages/ui-shared/src/components/Card/Card.test.tsx
+++ b/packages/ui-shared/src/components/Card/Card.test.tsx
@@ -21,6 +21,11 @@ const link = {
 };
 const svg = <WiFi style={{ display: 'block', fill: '#00B956' }} />;
 const classes = { root: 'rootClass', button: 'buttonClass', link: 'linkClass', inner: 'innerClass' };
+const dataAttrs = {
+    root: { 'data-testid': 'root-test' },
+    link: { 'data-testid': 'link-test' },
+    button: { 'data-testid': 'button-test' },
+};
 const imageSrc = '/test-src';
 
 describe('Card', () => {
@@ -39,7 +44,7 @@ describe('Card', () => {
                 link={link}
                 classes={classes}
                 className="className"
-                dataAttrs={{ 'data-test': 'value' }}
+                dataAttrs={dataAttrs}
                 isCenteredText
             />,
         );

--- a/packages/ui-shared/src/components/Card/Card.tsx
+++ b/packages/ui-shared/src/components/Card/Card.tsx
@@ -33,8 +33,12 @@ export const ObjectFit = {
 type ObjectFitType = typeof ObjectFit[keyof typeof ObjectFit];
 
 export interface ICard {
-    /** Дата атрибуты для корневого элемента */
-    dataAttrs?: { [key: string]: string };
+    /** Дополнительные data атрибуты к внутренним элементам */
+    dataAttrs?: {
+        root?: Record<string, string>;
+        link?: Record<string, string>;
+        button?: Record<string, string>;
+    };
     /** Дополнительный класс корневого элемента */
     className?: string;
     /** Дополнительные классы для корневого и внутренних элементов */
@@ -126,11 +130,17 @@ const Card: React.FC<ICard> = ({
         }
 
         return (
-            <TextLink className={cn('link', [classes.link])} href={linkHref} target={linkTarget} download={download}>
+            <TextLink
+                href={linkHref}
+                download={download}
+                target={linkTarget}
+                dataAttrs={{ root: dataAttrs?.link }}
+                className={cn('link', [classes.link])}
+            >
                 {linkTitle}
             </TextLink>
         );
-    }, [link, isCardLink, classes]);
+    }, [link, isCardLink, classes, dataAttrs?.link]);
 
     const renderBtn = React.useCallback(() => {
         if (!button || isCardLink) {
@@ -141,6 +151,7 @@ const Card: React.FC<ICard> = ({
 
         return (
             <Button
+                dataAttrs={{ root: dataAttrs?.button }}
                 className={cn('button', [classes.button])}
                 href={btnHref}
                 target={btnTarget}
@@ -149,7 +160,7 @@ const Card: React.FC<ICard> = ({
                 {btnTitle}
             </Button>
         );
-    }, [button, isCardLink, classes]);
+    }, [button, isCardLink, classes, dataAttrs?.button]);
 
     const renderBtnsWrapper = React.useCallback(() => {
         const btnElem = renderBtn();
@@ -169,7 +180,7 @@ const Card: React.FC<ICard> = ({
 
     return (
         <div
-            {...filterDataAttrs(dataAttrs)}
+            {...filterDataAttrs(dataAttrs?.root)}
             className={cn(
                 '',
                 {
@@ -196,7 +207,11 @@ const Card: React.FC<ICard> = ({
 };
 
 Card.propTypes = {
-    dataAttrs: PropTypes.objectOf(PropTypes.string.isRequired),
+    dataAttrs: PropTypes.shape({
+        root: PropTypes.objectOf(PropTypes.string.isRequired),
+        link: PropTypes.objectOf(PropTypes.string.isRequired),
+        button: PropTypes.objectOf(PropTypes.string.isRequired),
+    }),
     className: PropTypes.string,
     classes: PropTypes.shape({
         root: PropTypes.string,

--- a/packages/ui-shared/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/packages/ui-shared/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -83,11 +83,8 @@ exports[`Card disable left align if there is a button and link 1`] = `
       </Button>
       <TextLink
         className="mfui-card__link"
-        color="blue"
         href="#"
         target="_self"
-        underlineStyle="solid"
-        underlineVisibility="hover"
       >
         Подключить
       </TextLink>
@@ -128,11 +125,8 @@ exports[`Card left align of the interactive element 1`] = `
     >
       <TextLink
         className="mfui-card__link"
-        color="blue"
         href="#"
         target="_self"
-        underlineStyle="solid"
-        underlineVisibility="hover"
       >
         Подключить
       </TextLink>
@@ -183,11 +177,8 @@ exports[`Card render component with icon 1`] = `
       </Button>
       <TextLink
         className="mfui-card__link"
-        color="blue"
         href="#"
         target="_self"
-        underlineStyle="solid"
-        underlineVisibility="hover"
       >
         Подключить
       </TextLink>
@@ -235,11 +226,8 @@ exports[`Card render component with img, if image source and svg source are spec
       </Button>
       <TextLink
         className="mfui-card__link"
-        color="blue"
         href="#"
         target="_self"
-        underlineStyle="solid"
-        underlineVisibility="hover"
       >
         Подключить
       </TextLink>
@@ -288,11 +276,8 @@ exports[`Card render component with optional props 1`] = `
       </Button>
       <TextLink
         className="mfui-card__link linkClass"
-        color="blue"
         href="#"
         target="_self"
-        underlineStyle="solid"
-        underlineVisibility="hover"
       >
         Подключить
       </TextLink>
@@ -398,11 +383,8 @@ exports[`Card render with a single interactive link element 1`] = `
     >
       <TextLink
         className="mfui-card__link"
-        color="blue"
         href="#"
         target="_self"
-        underlineStyle="solid"
-        underlineVisibility="hover"
       >
         Подключить
       </TextLink>
@@ -442,12 +424,9 @@ exports[`Card render with attribute "download" for <Button> and <Textlink> 1`] =
       </Button>
       <TextLink
         className="mfui-card__link"
-        color="blue"
         download={true}
         href="#"
         target="_self"
-        underlineStyle="solid"
-        underlineVisibility="hover"
       >
         Подключить
       </TextLink>
@@ -595,11 +574,8 @@ exports[`Card render without img and svg 1`] = `
       </Button>
       <TextLink
         className="mfui-card__link"
-        color="blue"
         href="#"
         target="_self"
-        underlineStyle="solid"
-        underlineVisibility="hover"
       >
         Подключить
       </TextLink>

--- a/packages/ui-shared/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/packages/ui-shared/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -76,6 +76,11 @@ exports[`Card disable left align if there is a button and link 1`] = `
     >
       <Button
         className="mfui-card__button"
+        dataAttrs={
+          Object {
+            "root": undefined,
+          }
+        }
         href="#"
         target="_blank"
       >
@@ -83,6 +88,11 @@ exports[`Card disable left align if there is a button and link 1`] = `
       </Button>
       <TextLink
         className="mfui-card__link"
+        dataAttrs={
+          Object {
+            "root": undefined,
+          }
+        }
         href="#"
         target="_self"
       >
@@ -125,6 +135,11 @@ exports[`Card left align of the interactive element 1`] = `
     >
       <TextLink
         className="mfui-card__link"
+        dataAttrs={
+          Object {
+            "root": undefined,
+          }
+        }
         href="#"
         target="_self"
       >
@@ -170,6 +185,11 @@ exports[`Card render component with icon 1`] = `
     >
       <Button
         className="mfui-card__button"
+        dataAttrs={
+          Object {
+            "root": undefined,
+          }
+        }
         href="#"
         target="_blank"
       >
@@ -177,6 +197,11 @@ exports[`Card render component with icon 1`] = `
       </Button>
       <TextLink
         className="mfui-card__link"
+        dataAttrs={
+          Object {
+            "root": undefined,
+          }
+        }
         href="#"
         target="_self"
       >
@@ -219,6 +244,11 @@ exports[`Card render component with img, if image source and svg source are spec
     >
       <Button
         className="mfui-card__button"
+        dataAttrs={
+          Object {
+            "root": undefined,
+          }
+        }
         href="#"
         target="_blank"
       >
@@ -226,6 +256,11 @@ exports[`Card render component with img, if image source and svg source are spec
       </Button>
       <TextLink
         className="mfui-card__link"
+        dataAttrs={
+          Object {
+            "root": undefined,
+          }
+        }
         href="#"
         target="_self"
       >
@@ -239,7 +274,7 @@ exports[`Card render component with img, if image source and svg source are spec
 exports[`Card render component with optional props 1`] = `
 <div
   className="mfui-card mfui-card_centered-text className rootClass"
-  data-test="value"
+  data-testid="root-test"
 >
   <div
     className="mfui-card__inner innerClass"
@@ -269,6 +304,13 @@ exports[`Card render component with optional props 1`] = `
     >
       <Button
         className="mfui-card__button buttonClass"
+        dataAttrs={
+          Object {
+            "root": Object {
+              "data-testid": "button-test",
+            },
+          }
+        }
         href="#"
         target="_blank"
       >
@@ -276,6 +318,13 @@ exports[`Card render component with optional props 1`] = `
       </Button>
       <TextLink
         className="mfui-card__link linkClass"
+        dataAttrs={
+          Object {
+            "root": Object {
+              "data-testid": "link-test",
+            },
+          }
+        }
         href="#"
         target="_self"
       >
@@ -338,6 +387,11 @@ exports[`Card render with a single interactive button element 1`] = `
     >
       <Button
         className="mfui-card__button"
+        dataAttrs={
+          Object {
+            "root": undefined,
+          }
+        }
         href="#"
         target="_blank"
       >
@@ -383,6 +437,11 @@ exports[`Card render with a single interactive link element 1`] = `
     >
       <TextLink
         className="mfui-card__link"
+        dataAttrs={
+          Object {
+            "root": undefined,
+          }
+        }
         href="#"
         target="_self"
       >
@@ -416,6 +475,11 @@ exports[`Card render with attribute "download" for <Button> and <Textlink> 1`] =
     >
       <Button
         className="mfui-card__button"
+        dataAttrs={
+          Object {
+            "root": undefined,
+          }
+        }
         download={true}
         href="#"
         target="_blank"
@@ -424,6 +488,11 @@ exports[`Card render with attribute "download" for <Button> and <Textlink> 1`] =
       </Button>
       <TextLink
         className="mfui-card__link"
+        dataAttrs={
+          Object {
+            "root": undefined,
+          }
+        }
         download={true}
         href="#"
         target="_self"
@@ -467,6 +536,11 @@ exports[`Card render with contain object fit 1`] = `
     >
       <Button
         className="mfui-card__button"
+        dataAttrs={
+          Object {
+            "root": undefined,
+          }
+        }
         href="#"
         target="_blank"
       >
@@ -567,6 +641,11 @@ exports[`Card render without img and svg 1`] = `
     >
       <Button
         className="mfui-card__button"
+        dataAttrs={
+          Object {
+            "root": undefined,
+          }
+        }
         href="#"
         target="_blank"
       >
@@ -574,6 +653,11 @@ exports[`Card render without img and svg 1`] = `
       </Button>
       <TextLink
         className="mfui-card__link"
+        dataAttrs={
+          Object {
+            "root": undefined,
+          }
+        }
         href="#"
         target="_self"
       >

--- a/packages/ui-shared/src/components/CardsBox/__snapshots__/CardsBox.test.tsx.snap
+++ b/packages/ui-shared/src/components/CardsBox/__snapshots__/CardsBox.test.tsx.snap
@@ -61,6 +61,11 @@ exports[`CardsBox mobile resolution render with carousel 1`] = `
             >
               <Button
                 className="mfui-card__button"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="button-href"
               >
                 <a
@@ -86,10 +91,20 @@ exports[`CardsBox mobile resolution render with carousel 1`] = `
               </Button>
               <TextLink
                 className="mfui-card__link"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="href"
               >
                 <Link
                   className="mfui-text-link mfui-text-link_underline-visibility_hover mfui-text-link_underline-style_solid mfui-text-link_color_blue mfui-card__link"
+                  dataAttrs={
+                    Object {
+                      "root": undefined,
+                    }
+                  }
                   href="href"
                 >
                   <a
@@ -146,6 +161,11 @@ exports[`CardsBox mobile resolution render with carousel 1`] = `
             >
               <Button
                 className="mfui-card__button"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="button-href"
               >
                 <a
@@ -171,10 +191,20 @@ exports[`CardsBox mobile resolution render with carousel 1`] = `
               </Button>
               <TextLink
                 className="mfui-card__link"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="href"
               >
                 <Link
                   className="mfui-text-link mfui-text-link_underline-visibility_hover mfui-text-link_underline-style_solid mfui-text-link_color_blue mfui-card__link"
+                  dataAttrs={
+                    Object {
+                      "root": undefined,
+                    }
+                  }
                   href="href"
                 >
                   <a
@@ -231,6 +261,11 @@ exports[`CardsBox mobile resolution render with carousel 1`] = `
             >
               <Button
                 className="mfui-card__button"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="button-href"
               >
                 <a
@@ -256,10 +291,20 @@ exports[`CardsBox mobile resolution render with carousel 1`] = `
               </Button>
               <TextLink
                 className="mfui-card__link"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="href"
               >
                 <Link
                   className="mfui-text-link mfui-text-link_underline-visibility_hover mfui-text-link_underline-style_solid mfui-text-link_color_blue mfui-card__link"
+                  dataAttrs={
+                    Object {
+                      "root": undefined,
+                    }
+                  }
                   href="href"
                 >
                   <a

--- a/packages/ui-shared/src/components/CardsBox/__snapshots__/CardsBox.test.tsx.snap
+++ b/packages/ui-shared/src/components/CardsBox/__snapshots__/CardsBox.test.tsx.snap
@@ -86,10 +86,7 @@ exports[`CardsBox mobile resolution render with carousel 1`] = `
               </Button>
               <TextLink
                 className="mfui-card__link"
-                color="blue"
                 href="href"
-                underlineStyle="solid"
-                underlineVisibility="hover"
               >
                 <Link
                   className="mfui-text-link mfui-text-link_underline-visibility_hover mfui-text-link_underline-style_solid mfui-text-link_color_blue mfui-card__link"
@@ -174,10 +171,7 @@ exports[`CardsBox mobile resolution render with carousel 1`] = `
               </Button>
               <TextLink
                 className="mfui-card__link"
-                color="blue"
                 href="href"
-                underlineStyle="solid"
-                underlineVisibility="hover"
               >
                 <Link
                   className="mfui-text-link mfui-text-link_underline-visibility_hover mfui-text-link_underline-style_solid mfui-text-link_color_blue mfui-card__link"
@@ -262,10 +256,7 @@ exports[`CardsBox mobile resolution render with carousel 1`] = `
               </Button>
               <TextLink
                 className="mfui-card__link"
-                color="blue"
                 href="href"
-                underlineStyle="solid"
-                underlineVisibility="hover"
               >
                 <Link
                   className="mfui-text-link mfui-text-link_underline-visibility_hover mfui-text-link_underline-style_solid mfui-text-link_color_blue mfui-card__link"

--- a/packages/ui-shared/src/components/Container/__snapshots__/Container.test.tsx.snap
+++ b/packages/ui-shared/src/components/Container/__snapshots__/Container.test.tsx.snap
@@ -4,10 +4,7 @@ exports[`Container should renders component with default props 1`] = `
 <div
   className="mfui-container mfui-container_bg-color_default"
 >
-  <ContentArea
-    innerBackgroundColor="transparent"
-    outerBackgroundColor="transparent"
-  >
+  <ContentArea>
     <TitleDescriptionBox
       title="title"
     />
@@ -20,10 +17,7 @@ exports[`Container should renders component with optional props 1`] = `
   className="mfui-container mfui-container_bg-color_green mfui-container_disable-padding-top mfui-container_disable-padding-bottom className"
   id="id"
 >
-  <ContentArea
-    innerBackgroundColor="transparent"
-    outerBackgroundColor="transparent"
-  >
+  <ContentArea>
     <TitleDescriptionBox
       title="title"
     />

--- a/packages/ui-shared/src/components/DownloadLinks/DownloadLink.less
+++ b/packages/ui-shared/src/components/DownloadLinks/DownloadLink.less
@@ -26,7 +26,7 @@
     &__info {
         margin: 0;
         .smallFont();
-        color: var(--stcBlack5);
+        color: var(--spbSky3);
         text-transform: uppercase;
     }
 }

--- a/packages/ui-shared/src/components/DownloadLinks/DownloadLink.test.tsx
+++ b/packages/ui-shared/src/components/DownloadLinks/DownloadLink.test.tsx
@@ -15,7 +15,7 @@ describe('DownloadLink', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    it('render with custom classes', () => {
+    it('render with custom classes and data-attributes', () => {
         const wrapper = shallow(
             <DownloadLink
                 {...props}
@@ -24,6 +24,7 @@ describe('DownloadLink', () => {
                     root: 'root-class',
                     link: 'link-class',
                 }}
+                dataAttrs={{ root: { 'data-testid': 'root-test' }, link: { 'data-testid': 'link-test' } }}
             />,
         );
         expect(wrapper).toMatchSnapshot();

--- a/packages/ui-shared/src/components/DownloadLinks/DownloadLink.tsx
+++ b/packages/ui-shared/src/components/DownloadLinks/DownloadLink.tsx
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import { TextLink } from '@megafon/ui-core';
-import { cnCreate } from '@megafon/ui-helpers';
+import { cnCreate, filterDataAttrs } from '@megafon/ui-helpers';
 import DownloadIcon from '@megafon/ui-icons/basic-32-download_32.svg';
 import * as PropTypes from 'prop-types';
 import './DownloadLink.less';
 
 export interface IDownloadLink {
+    /** Дополнительные data атрибуты к внутренним элементам */
+    dataAttrs?: {
+        root?: Record<string, string>;
+        link?: Record<string, string>;
+    };
     /** Ссылка на корневой элемент */
     rootRef?: React.Ref<HTMLDivElement>;
     /** Адресы ссылки */
@@ -37,13 +42,20 @@ const DownloadLink: React.FC<IDownloadLink> = ({
     className,
     classes = {},
     rootRef,
+    dataAttrs,
 }) => (
-    <div className={cn([className, classes.root])} ref={rootRef}>
+    <div {...filterDataAttrs(dataAttrs?.root)} className={cn([className, classes.root])} ref={rootRef}>
         <div className={cn('icon')}>
             <DownloadIcon className={cn('icon-svg')} />
         </div>
         <div>
-            <TextLink className={cn('link', [classes.link])} href={href} onClick={onClick} download>
+            <TextLink
+                download
+                href={href}
+                onClick={onClick}
+                dataAttrs={{ root: dataAttrs?.link }}
+                className={cn('link', [classes.link])}
+            >
                 {text}
             </TextLink>
             <p className={cn('info')}>{`${extension}${extension && fileSize ? ',' : ''} ${fileSize}`}</p>
@@ -52,6 +64,10 @@ const DownloadLink: React.FC<IDownloadLink> = ({
 );
 
 DownloadLink.propTypes = {
+    dataAttrs: PropTypes.shape({
+        root: PropTypes.objectOf(PropTypes.string.isRequired),
+        link: PropTypes.objectOf(PropTypes.string.isRequired),
+    }),
     rootRef: PropTypes.oneOfType([
         PropTypes.func,
         PropTypes.oneOfType([PropTypes.shape({ current: PropTypes.elementType }), PropTypes.any]),

--- a/packages/ui-shared/src/components/DownloadLinks/__snapshots__/DownloadLink.test.tsx.snap
+++ b/packages/ui-shared/src/components/DownloadLinks/__snapshots__/DownloadLink.test.tsx.snap
@@ -14,11 +14,8 @@ exports[`DownloadLink render component 1`] = `
   <div>
     <TextLink
       className="mfui-download-link__link"
-      color="blue"
       download={true}
       href="href"
-      underlineStyle="solid"
-      underlineVisibility="hover"
     >
       text
     </TextLink>
@@ -45,11 +42,8 @@ exports[`DownloadLink render with custom classes 1`] = `
   <div>
     <TextLink
       className="mfui-download-link__link link-class"
-      color="blue"
       download={true}
       href="href"
-      underlineStyle="solid"
-      underlineVisibility="hover"
     >
       text
     </TextLink>

--- a/packages/ui-shared/src/components/DownloadLinks/__snapshots__/DownloadLink.test.tsx.snap
+++ b/packages/ui-shared/src/components/DownloadLinks/__snapshots__/DownloadLink.test.tsx.snap
@@ -14,6 +14,11 @@ exports[`DownloadLink render component 1`] = `
   <div>
     <TextLink
       className="mfui-download-link__link"
+      dataAttrs={
+        Object {
+          "root": undefined,
+        }
+      }
       download={true}
       href="href"
     >
@@ -28,9 +33,10 @@ exports[`DownloadLink render component 1`] = `
 </div>
 `;
 
-exports[`DownloadLink render with custom classes 1`] = `
+exports[`DownloadLink render with custom classes and data-attributes 1`] = `
 <div
   className="mfui-download-link custom-classname root-class"
+  data-testid="root-test"
 >
   <div
     className="mfui-download-link__icon"
@@ -42,6 +48,13 @@ exports[`DownloadLink render with custom classes 1`] = `
   <div>
     <TextLink
       className="mfui-download-link__link link-class"
+      dataAttrs={
+        Object {
+          "root": Object {
+            "data-testid": "link-test",
+          },
+        }
+      }
       download={true}
       href="href"
     >

--- a/packages/ui-shared/src/components/Instructions/Instructions.test.tsx
+++ b/packages/ui-shared/src/components/Instructions/Instructions.test.tsx
@@ -38,6 +38,22 @@ describe('<Instructions />', () => {
             expect(wrapper).toMatchSnapshot();
         });
 
+        it('should render with data-attributes', () => {
+            const wrapper = shallow(
+                <Instructions
+                    {...props}
+                    dataAttrs={{
+                        root: { 'data-testid': 'root-test' },
+                        item: { 'data-testid': 'item-test' },
+                        image: { 'data-testid': 'image-test' },
+                        mobileItemText: { 'data-testid': 'mobileItemText-test' },
+                    }}
+                />,
+            );
+
+            expect(wrapper).toMatchSnapshot();
+        });
+
         it('should render with right side picture', () => {
             const newProps = {
                 ...props,
@@ -95,6 +111,22 @@ describe('<Instructions />', () => {
 
         it('should render with default props', () => {
             const wrapper = mount(<Instructions {...props} />);
+
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        it('should render with data-attributes', () => {
+            const wrapper = shallow(
+                <Instructions
+                    {...props}
+                    dataAttrs={{
+                        root: { 'data-testid': 'root-test' },
+                        item: { 'data-testid': 'item-test' },
+                        image: { 'data-testid': 'image-test' },
+                        mobileItemText: { 'data-testid': 'mobileItemText-test' },
+                    }}
+                />,
+            );
 
             expect(wrapper).toMatchSnapshot();
         });

--- a/packages/ui-shared/src/components/Instructions/Instructions.tsx
+++ b/packages/ui-shared/src/components/Instructions/Instructions.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import React, { Ref } from 'react';
 import { Grid, GridColumn, Header, Paragraph } from '@megafon/ui-core';
-import { cnCreate } from '@megafon/ui-helpers';
+import { cnCreate, filterDataAttrs } from '@megafon/ui-helpers';
 import convert from 'htmr';
 import PropTypes from 'prop-types';
 import SwiperCore from 'swiper';
@@ -36,6 +36,13 @@ export type InstructionItemType = {
 };
 
 export interface IInstructionsProps {
+    /** Дополнительные data атрибуты к внутренним элементам */
+    dataAttrs?: {
+        root?: Record<string, string>;
+        item?: Record<string, string>;
+        image?: Record<string, string>;
+        mobileItemText?: Record<string, string>;
+    };
     /** Ссылка на корневой элемент */
     rootRef?: Ref<HTMLDivElement>;
     /** Дополнительные классы для внутренних элементов */
@@ -66,6 +73,7 @@ export interface IInstructionsProps {
 const cn = cnCreate('mfui-instructions');
 const swiperSlideCn = cn('slide');
 const Instructions: React.FC<IInstructionsProps> = ({
+    dataAttrs,
     rootRef,
     classes: {
         instructionItem,
@@ -115,29 +123,41 @@ const Instructions: React.FC<IInstructionsProps> = ({
     );
 
     const renderVideo = React.useCallback(
-        (mediaUrl: string): JSX.Element => (
-            <video className={cn('swiper-img')} autoPlay muted loop playsInline>
+        (mediaUrl: string, index: number): JSX.Element => (
+            <video
+                loop
+                muted
+                autoPlay
+                playsInline
+                className={cn('swiper-img')}
+                {...filterDataAttrs(dataAttrs?.image, index + 1)}
+            >
                 <source src={mediaUrl} type="video/mp4" />
             </video>
         ),
-        [],
+        [dataAttrs?.image],
     );
 
     const renderSlider = React.useCallback(
         (): JSX.Element => (
             <Swiper className={cn('swiper')} onSwiper={getSwiperInstance} noSwipingClass={swiperSlideCn}>
-                {instructionItems.map(({ mediaUrl, isVideo }, ind) => (
-                    <SwiperSlide className={swiperSlideCn} key={ind + mediaUrl}>
+                {instructionItems.map(({ mediaUrl, isVideo }, i) => (
+                    <SwiperSlide className={swiperSlideCn} key={i + mediaUrl}>
                         {isVideo ? (
-                            renderVideo(mediaUrl)
+                            renderVideo(mediaUrl, i)
                         ) : (
-                            <img className={cn('swiper-img', [instructionItemImg])} src={mediaUrl} alt="" />
+                            <img
+                                alt=""
+                                src={mediaUrl}
+                                {...filterDataAttrs(dataAttrs?.image, i + 1)}
+                                className={cn('swiper-img', [instructionItemImg])}
+                            />
                         )}
                     </SwiperSlide>
                 ))}
             </Swiper>
         ),
-        [getSwiperInstance, instructionItemImg, instructionItems, renderVideo],
+        [getSwiperInstance, instructionItemImg, instructionItems, renderVideo, dataAttrs?.image],
     );
 
     const renderTitle = React.useCallback(
@@ -174,20 +194,21 @@ const Instructions: React.FC<IInstructionsProps> = ({
     const renderDesktopArticles = React.useCallback(
         (): JSX.Element => (
             <ul className={cn('articles-list', { 'text-after': !!text, desktop: true })}>
-                {instructionItems.map(({ title: itemTitle }, ind) => (
+                {instructionItems.map(({ title: itemTitle }, i) => (
                     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
                     <li
-                        className={cn('articles-item', { active: slideIndex === ind }, [
-                            getActiveCustomClass(ind, slideIndex),
+                        {...filterDataAttrs(dataAttrs?.item, i + 1)}
+                        className={cn('articles-item', { active: slideIndex === i }, [
+                            getActiveCustomClass(i, slideIndex),
                             instructionItem,
                             desktopInstructionItem,
                         ])}
-                        data-index={ind}
-                        onClick={handleArticleClick(ind)}
-                        key={ind}
+                        data-index={i}
+                        onClick={handleArticleClick(i)}
+                        key={i}
                     >
                         <div className={cn('articles-item-dot')}>
-                            <span className={cn('articles-item-dot-number')}>{ind + 1}</span>
+                            <span className={cn('articles-item-dot-number')}>{i + 1}</span>
                         </div>
                         <div className={cn('articles-item-title', [desktopItemTitle])}>{itemTitle}</div>
                     </li>
@@ -199,6 +220,7 @@ const Instructions: React.FC<IInstructionsProps> = ({
             desktopItemTitle,
             getActiveCustomClass,
             handleArticleClick,
+            dataAttrs?.item,
             instructionItem,
             instructionItems,
             slideIndex,
@@ -211,45 +233,53 @@ const Instructions: React.FC<IInstructionsProps> = ({
             <div className={cn('articles-list', { mobile: true })}>
                 <div className={cn('articles-title-block')}>
                     {instructionItems.map(
-                        ({ title: itemTitle }, ind) =>
-                            slideIndex === ind && (
-                                <div className={cn('articles-title', [mobileItemTitle])} data-index={ind} key={ind}>
+                        ({ title: itemTitle }, i) =>
+                            slideIndex === i && (
+                                <div
+                                    key={i}
+                                    data-index={i}
+                                    {...filterDataAttrs(dataAttrs?.mobileItemText, i + 1)}
+                                    className={cn('articles-title', [mobileItemTitle])}
+                                >
                                     {itemTitle}
                                 </div>
                             ),
                     )}
                 </div>
                 <ul className={cn('articles-dots', { 'text-after': !!text })}>
-                    {instructionItems.map((_item, ind) => (
+                    {instructionItems.map((_item, i) => (
                         <div
-                            key={ind}
-                            className={cn('articles-dot', { active: slideIndex === ind }, [
-                                getActiveCustomClass(ind, slideIndex),
+                            {...filterDataAttrs(dataAttrs?.item, i + 1)}
+                            key={i}
+                            className={cn('articles-dot', { active: slideIndex === i }, [
+                                getActiveCustomClass(i, slideIndex),
                                 instructionItem,
                                 mobileInstructionItem,
                             ])}
-                            onClick={handleArticleClick(ind)}
+                            onClick={handleArticleClick(i)}
                         >
-                            <span className={cn('articles-dot-number')}>{ind + 1}</span>
+                            <span className={cn('articles-dot-number')}>{i + 1}</span>
                         </div>
                     ))}
                 </ul>
             </div>
         ),
         [
+            dataAttrs?.mobileItemText,
             getActiveCustomClass,
             handleArticleClick,
             instructionItem,
             instructionItems,
             mobileInstructionItem,
             mobileItemTitle,
+            dataAttrs?.item,
             slideIndex,
             text,
         ],
     );
 
     return (
-        <div className={cn({ mask: pictureMask })} ref={rootRef}>
+        <div {...filterDataAttrs(dataAttrs?.root)} className={cn({ mask: pictureMask })} ref={rootRef}>
             <Grid hAlign="center">
                 <GridColumn all="12">
                     {renderTitle('mobile')}
@@ -269,6 +299,12 @@ const Instructions: React.FC<IInstructionsProps> = ({
 };
 
 Instructions.propTypes = {
+    dataAttrs: PropTypes.shape({
+        root: PropTypes.objectOf(PropTypes.string.isRequired),
+        item: PropTypes.objectOf(PropTypes.string.isRequired),
+        image: PropTypes.objectOf(PropTypes.string.isRequired),
+        mobileItemText: PropTypes.objectOf(PropTypes.string.isRequired),
+    }),
     rootRef: PropTypes.oneOfType([
         PropTypes.func,
         PropTypes.oneOfType([PropTypes.shape({ current: PropTypes.elementType }), PropTypes.any]),

--- a/packages/ui-shared/src/components/Instructions/__snapshots__/Instructions.test.tsx.snap
+++ b/packages/ui-shared/src/components/Instructions/__snapshots__/Instructions.test.tsx.snap
@@ -159,6 +159,173 @@ exports[`<Instructions /> desktop resolution active slide will be changed 1`] = 
 </div>
 `;
 
+exports[`<Instructions /> desktop resolution should render with data-attributes 1`] = `
+<div
+  className="mfui-instructions mfui-instructions_mask_none"
+  data-testid="root-test"
+>
+  <Grid
+    hAlign="center"
+  >
+    <GridColumn
+      all="12"
+    >
+      <Header
+        as="h2"
+        className="mfui-instructions__title mfui-instructions__title_resolution_mobile"
+      >
+        Test instruction title
+      </Header>
+      <div
+        className="mfui-instructions__wrapper"
+      >
+        <div
+          className="mfui-instructions__picture mfui-instructions__picture_align_left"
+        >
+          <Swiper
+            className="mfui-instructions__swiper"
+            noSwipingClass="mfui-instructions__slide"
+            onSwiper={[Function]}
+          >
+            <SwiperSlide
+              className="mfui-instructions__slide"
+              key="0ImgUrl1"
+            >
+              <video
+                autoPlay={true}
+                className="mfui-instructions__swiper-img"
+                data-testid="image-test[1]"
+                loop={true}
+                muted={true}
+                playsInline={true}
+              >
+                <source
+                  src="ImgUrl1"
+                  type="video/mp4"
+                />
+              </video>
+            </SwiperSlide>
+            <SwiperSlide
+              className="mfui-instructions__slide"
+              key="1ImgUrl2"
+            >
+              <img
+                alt=""
+                className="mfui-instructions__swiper-img"
+                data-testid="image-test[2]"
+                src="ImgUrl2"
+              />
+            </SwiperSlide>
+          </Swiper>
+        </div>
+        <div
+          className="mfui-instructions__articles mfui-instructions__articles_align_left"
+        >
+          <Header
+            as="h2"
+            className="mfui-instructions__title mfui-instructions__title_resolution_desktop"
+          >
+            Test instruction title
+          </Header>
+          <div
+            className="mfui-instructions__articles-list mfui-instructions__articles-list_mobile"
+          >
+            <div
+              className="mfui-instructions__articles-title-block"
+            >
+              <div
+                className="mfui-instructions__articles-title"
+                data-index={0}
+                data-testid="mobileItemText-test[1]"
+                key="0"
+              >
+                Test1
+              </div>
+            </div>
+            <ul
+              className="mfui-instructions__articles-dots"
+            >
+              <div
+                className="mfui-instructions__articles-dot mfui-instructions__articles-dot_active"
+                data-testid="item-test[1]"
+                key="0"
+                onClick={[Function]}
+              >
+                <span
+                  className="mfui-instructions__articles-dot-number"
+                >
+                  1
+                </span>
+              </div>
+              <div
+                className="mfui-instructions__articles-dot"
+                data-testid="item-test[2]"
+                key="1"
+                onClick={[Function]}
+              >
+                <span
+                  className="mfui-instructions__articles-dot-number"
+                >
+                  2
+                </span>
+              </div>
+            </ul>
+          </div>
+          <ul
+            className="mfui-instructions__articles-list mfui-instructions__articles-list_desktop"
+          >
+            <li
+              className="mfui-instructions__articles-item mfui-instructions__articles-item_active"
+              data-index={0}
+              data-testid="item-test[1]"
+              key="0"
+              onClick={[Function]}
+            >
+              <div
+                className="mfui-instructions__articles-item-dot"
+              >
+                <span
+                  className="mfui-instructions__articles-item-dot-number"
+                >
+                  1
+                </span>
+              </div>
+              <div
+                className="mfui-instructions__articles-item-title"
+              >
+                Test1
+              </div>
+            </li>
+            <li
+              className="mfui-instructions__articles-item"
+              data-index={1}
+              data-testid="item-test[2]"
+              key="1"
+              onClick={[Function]}
+            >
+              <div
+                className="mfui-instructions__articles-item-dot"
+              >
+                <span
+                  className="mfui-instructions__articles-item-dot-number"
+                >
+                  2
+                </span>
+              </div>
+              <div
+                className="mfui-instructions__articles-item-title"
+              >
+                Test2
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </GridColumn>
+  </Grid>
+</div>
+`;
+
 exports[`<Instructions /> desktop resolution should render with default props 1`] = `
 <div
   className="mfui-instructions mfui-instructions_mask_none"
@@ -783,6 +950,173 @@ exports[`<Instructions /> desktop resolution should render with right side pictu
             <li
               className="mfui-instructions__articles-item"
               data-index={1}
+              key="1"
+              onClick={[Function]}
+            >
+              <div
+                className="mfui-instructions__articles-item-dot"
+              >
+                <span
+                  className="mfui-instructions__articles-item-dot-number"
+                >
+                  2
+                </span>
+              </div>
+              <div
+                className="mfui-instructions__articles-item-title"
+              >
+                Test2
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </GridColumn>
+  </Grid>
+</div>
+`;
+
+exports[`<Instructions /> mobile resolution should render with data-attributes 1`] = `
+<div
+  className="mfui-instructions mfui-instructions_mask_none"
+  data-testid="root-test"
+>
+  <Grid
+    hAlign="center"
+  >
+    <GridColumn
+      all="12"
+    >
+      <Header
+        as="h2"
+        className="mfui-instructions__title mfui-instructions__title_resolution_mobile"
+      >
+        Test instruction title
+      </Header>
+      <div
+        className="mfui-instructions__wrapper"
+      >
+        <div
+          className="mfui-instructions__picture mfui-instructions__picture_align_left"
+        >
+          <Swiper
+            className="mfui-instructions__swiper"
+            noSwipingClass="mfui-instructions__slide"
+            onSwiper={[Function]}
+          >
+            <SwiperSlide
+              className="mfui-instructions__slide"
+              key="0ImgUrl1"
+            >
+              <video
+                autoPlay={true}
+                className="mfui-instructions__swiper-img"
+                data-testid="image-test[1]"
+                loop={true}
+                muted={true}
+                playsInline={true}
+              >
+                <source
+                  src="ImgUrl1"
+                  type="video/mp4"
+                />
+              </video>
+            </SwiperSlide>
+            <SwiperSlide
+              className="mfui-instructions__slide"
+              key="1ImgUrl2"
+            >
+              <img
+                alt=""
+                className="mfui-instructions__swiper-img"
+                data-testid="image-test[2]"
+                src="ImgUrl2"
+              />
+            </SwiperSlide>
+          </Swiper>
+        </div>
+        <div
+          className="mfui-instructions__articles mfui-instructions__articles_align_left"
+        >
+          <Header
+            as="h2"
+            className="mfui-instructions__title mfui-instructions__title_resolution_desktop"
+          >
+            Test instruction title
+          </Header>
+          <div
+            className="mfui-instructions__articles-list mfui-instructions__articles-list_mobile"
+          >
+            <div
+              className="mfui-instructions__articles-title-block"
+            >
+              <div
+                className="mfui-instructions__articles-title"
+                data-index={0}
+                data-testid="mobileItemText-test[1]"
+                key="0"
+              >
+                Test1
+              </div>
+            </div>
+            <ul
+              className="mfui-instructions__articles-dots"
+            >
+              <div
+                className="mfui-instructions__articles-dot mfui-instructions__articles-dot_active"
+                data-testid="item-test[1]"
+                key="0"
+                onClick={[Function]}
+              >
+                <span
+                  className="mfui-instructions__articles-dot-number"
+                >
+                  1
+                </span>
+              </div>
+              <div
+                className="mfui-instructions__articles-dot"
+                data-testid="item-test[2]"
+                key="1"
+                onClick={[Function]}
+              >
+                <span
+                  className="mfui-instructions__articles-dot-number"
+                >
+                  2
+                </span>
+              </div>
+            </ul>
+          </div>
+          <ul
+            className="mfui-instructions__articles-list mfui-instructions__articles-list_desktop"
+          >
+            <li
+              className="mfui-instructions__articles-item mfui-instructions__articles-item_active"
+              data-index={0}
+              data-testid="item-test[1]"
+              key="0"
+              onClick={[Function]}
+            >
+              <div
+                className="mfui-instructions__articles-item-dot"
+              >
+                <span
+                  className="mfui-instructions__articles-item-dot-number"
+                >
+                  1
+                </span>
+              </div>
+              <div
+                className="mfui-instructions__articles-item-title"
+              >
+                Test1
+              </div>
+            </li>
+            <li
+              className="mfui-instructions__articles-item"
+              data-index={1}
+              data-testid="item-test[2]"
               key="1"
               onClick={[Function]}
             >

--- a/packages/ui-shared/src/components/PageTitle/PageTitle.test.tsx
+++ b/packages/ui-shared/src/components/PageTitle/PageTitle.test.tsx
@@ -34,6 +34,11 @@ describe('PageTitle', () => {
                 badge={badge}
                 className="custom-class-name"
                 classes={{ breadcrumbs: 'breadcrumbs-custom-class-name' }}
+                dataAttrs={{
+                    root: { 'data-testid': 'root-test' },
+                    breadcrumbs: { 'data-testid': 'breadcrumbs-test' },
+                    breadcrumbsLink: { 'data-testid': 'breadcrumbsLink-test' },
+                }}
             />,
         );
 

--- a/packages/ui-shared/src/components/PageTitle/PageTitle.tsx
+++ b/packages/ui-shared/src/components/PageTitle/PageTitle.tsx
@@ -1,11 +1,17 @@
 import * as React from 'react';
 import { Header, Grid, GridColumn } from '@megafon/ui-core';
-import { cnCreate } from '@megafon/ui-helpers';
+import { cnCreate, filterDataAttrs } from '@megafon/ui-helpers';
 import PropTypes from 'prop-types';
 import './PageTitle.less';
 import Breadcrumbs, { Props as BreadcrumbsType } from '../Breadcrumbs/Breadcrumbs';
 
 type Props = {
+    /** Дополнительные data атрибуты к внутренним элементам */
+    dataAttrs?: {
+        root?: Record<string, string>;
+        breadcrumbs?: Record<string, string>;
+        breadcrumbsLink?: Record<string, string>;
+    };
     /** Текст заголовка */
     title: string | React.ReactNode | React.ReactNode[];
     /** Хлебные крошки */
@@ -26,6 +32,7 @@ type Props = {
 
 const cn = cnCreate('mfui-page-title');
 const PageTitle: React.FC<Props> = ({
+    dataAttrs,
     title,
     breadcrumbs,
     badge,
@@ -60,9 +67,13 @@ const PageTitle: React.FC<Props> = ({
     );
 
     return (
-        <div className={cn([className])} ref={rootRef}>
+        <div {...filterDataAttrs(dataAttrs?.root)} className={cn([className])} ref={rootRef}>
             {breadcrumbs?.length && (
-                <Breadcrumbs items={breadcrumbs} className={cn('breadcrumbs', [classes.breadcrumbs])} />
+                <Breadcrumbs
+                    items={breadcrumbs}
+                    dataAttrs={{ root: dataAttrs?.breadcrumbs, link: dataAttrs?.breadcrumbsLink }}
+                    className={cn('breadcrumbs', [classes.breadcrumbs])}
+                />
             )}
             {isFullWidth ? renderPageTitle() : renderPageTitleWithGrid()}
         </div>
@@ -70,6 +81,11 @@ const PageTitle: React.FC<Props> = ({
 };
 
 PageTitle.propTypes = {
+    dataAttrs: PropTypes.shape({
+        root: PropTypes.objectOf(PropTypes.string.isRequired),
+        breadcrumbs: PropTypes.objectOf(PropTypes.string.isRequired),
+        breadcrumbsLink: PropTypes.objectOf(PropTypes.string.isRequired),
+    }),
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]).isRequired,
     breadcrumbs: PropTypes.arrayOf(
         PropTypes.shape({

--- a/packages/ui-shared/src/components/PageTitle/__snapshots__/PageTitle.test.tsx.snap
+++ b/packages/ui-shared/src/components/PageTitle/__snapshots__/PageTitle.test.tsx.snap
@@ -19,6 +19,12 @@ exports[`PageTitle should render with limited width 1`] = `
 >
   <Breadcrumbs
     className="mfui-page-title__breadcrumbs"
+    dataAttrs={
+      Object {
+        "link": undefined,
+        "root": undefined,
+      }
+    }
     items={
       Array [
         Object {
@@ -62,9 +68,20 @@ exports[`PageTitle should render with limited width 1`] = `
 exports[`PageTitle should render with optional props 1`] = `
 <div
   className="mfui-page-title custom-class-name"
+  data-testid="root-test"
 >
   <Breadcrumbs
     className="mfui-page-title__breadcrumbs breadcrumbs-custom-class-name"
+    dataAttrs={
+      Object {
+        "link": Object {
+          "data-testid": "breadcrumbsLink-test",
+        },
+        "root": Object {
+          "data-testid": "breadcrumbs-test",
+        },
+      }
+    }
     items={
       Array [
         Object {

--- a/packages/ui-shared/src/components/Partners/Partners.test.tsx
+++ b/packages/ui-shared/src/components/Partners/Partners.test.tsx
@@ -87,9 +87,13 @@ describe('<Partners />', () => {
     });
 
     it('checking setting of data attributes', () => {
-        const testAttrValue = 'data-test';
-        const wrapper = shallow(<Partners items={generateItems(12, '#')} dataAttrs={{ 'data-test': testAttrValue }} />);
+        const wrapper = shallow(
+            <Partners
+                items={generateItems(6, '#')}
+                dataAttrs={{ root: { 'data-testid': 'root-test' }, item: { 'data-testid': 'item-test' } }}
+            />,
+        );
 
-        expect(wrapper.prop('data-test')).toEqual(testAttrValue);
+        expect(wrapper).toMatchSnapshot();
     });
 });

--- a/packages/ui-shared/src/components/Partners/Partners.tsx
+++ b/packages/ui-shared/src/components/Partners/Partners.tsx
@@ -11,6 +11,11 @@ export type ItemType = {
 };
 
 export interface IPartnersProps {
+    /** Дополнительные data атрибуты к внутренним элементам */
+    dataAttrs?: {
+        root?: Record<string, string>;
+        item?: Record<string, string>;
+    };
     /** Ссылка на корневой элемент */
     rootRef?: React.Ref<HTMLDivElement>;
     /** Дополнительные классы для корневого и внутренних элементов */
@@ -18,8 +23,6 @@ export interface IPartnersProps {
         root?: string;
         itemClass?: string;
     };
-    /** Дата атрибуты для корневого элемента */
-    dataAttrs?: { [key: string]: string };
     /** Дополнительный класс корневого элемента */
     className?: string;
     /** Список логотипов */
@@ -61,7 +64,7 @@ const Partners: React.FC<IPartnersProps> = ({
     onPrevClick,
 }) => {
     const renderItem = React.useCallback(
-        (item?: ItemType) => {
+        (item?: ItemType, index = 0) => {
             if (!item) {
                 return null;
             }
@@ -69,7 +72,13 @@ const Partners: React.FC<IPartnersProps> = ({
             const { src, href, alt } = item;
 
             return (
-                <Tile className={cn('tile')} href={href} shadowLevel="low" isInteractive={!!href}>
+                <Tile
+                    href={href}
+                    shadowLevel="low"
+                    isInteractive={!!href}
+                    className={cn('tile')}
+                    dataAttrs={{ root: { ...filterDataAttrs(dataAttrs?.item, index + 1) } }}
+                >
                     <div className={cn('tile-inner', [itemClass])}>
                         <div className={cn('img-wrapper')}>
                             <img src={src} alt={alt} className={cn('tile-img')} />
@@ -78,7 +87,7 @@ const Partners: React.FC<IPartnersProps> = ({
                 </Tile>
             );
         },
-        [itemClass],
+        [itemClass, dataAttrs?.item],
     );
 
     const renderGrid = React.useCallback(
@@ -86,7 +95,7 @@ const Partners: React.FC<IPartnersProps> = ({
             <Grid guttersLeft="medium" guttersBottom="medium">
                 {items.map((item, i) => (
                     <GridColumn key={i + item.src} all="3" mobile="6">
-                        {renderItem(item)}
+                        {renderItem(item, i)}
                     </GridColumn>
                 ))}
             </Grid>
@@ -108,8 +117,8 @@ const Partners: React.FC<IPartnersProps> = ({
             >
                 {topRow.map((item, i) => (
                     <div key={i + item.src} className={cn('slide')}>
-                        {renderItem(item)}
-                        {renderItem(bottomRow[i])}
+                        {renderItem(item, i)}
+                        {renderItem(bottomRow[i], i)}
                     </div>
                 ))}
             </Carousel>
@@ -117,7 +126,7 @@ const Partners: React.FC<IPartnersProps> = ({
     }, [items, onChange, onNextClick, onPrevClick, renderItem]);
 
     return (
-        <div ref={rootRef} className={cn([root, className])} {...filterDataAttrs(dataAttrs)}>
+        <div ref={rootRef} className={cn([root, className])} {...filterDataAttrs(dataAttrs?.root)}>
             {items.length > MAX_GRID_ITEMS_LENGTH ? renderCarousel() : renderGrid()}
         </div>
     );
@@ -132,7 +141,10 @@ Partners.propTypes = {
         root: PropTypes.string,
         itemClass: PropTypes.string,
     }),
-    dataAttrs: PropTypes.objectOf(PropTypes.string.isRequired),
+    dataAttrs: PropTypes.shape({
+        root: PropTypes.objectOf(PropTypes.string.isRequired),
+        item: PropTypes.objectOf(PropTypes.string.isRequired),
+    }),
     className: PropTypes.string,
     items: PropTypes.arrayOf(
         PropTypes.shape({

--- a/packages/ui-shared/src/components/Partners/__snapshots__/Partners.test.tsx.snap
+++ b/packages/ui-shared/src/components/Partners/__snapshots__/Partners.test.tsx.snap
@@ -1,5 +1,216 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Partners /> checking setting of data attributes 1`] = `
+<div
+  className="mfui-partners"
+  data-testid="root-test"
+>
+  <Grid
+    guttersBottom="medium"
+    guttersLeft="medium"
+  >
+    <GridColumn
+      all="3"
+      key="0/test-src"
+      mobile="6"
+    >
+      <Tile
+        className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {
+              "data-testid": "item-test[1]",
+            },
+          }
+        }
+        href="#"
+        isInteractive={true}
+        shadowLevel="low"
+      >
+        <div
+          className="mfui-partners__tile-inner"
+        >
+          <div
+            className="mfui-partners__img-wrapper"
+          >
+            <img
+              alt="test img"
+              className="mfui-partners__tile-img"
+              src="/test-src"
+            />
+          </div>
+        </div>
+      </Tile>
+    </GridColumn>
+    <GridColumn
+      all="3"
+      key="1/test-src"
+      mobile="6"
+    >
+      <Tile
+        className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {
+              "data-testid": "item-test[2]",
+            },
+          }
+        }
+        href="#"
+        isInteractive={true}
+        shadowLevel="low"
+      >
+        <div
+          className="mfui-partners__tile-inner"
+        >
+          <div
+            className="mfui-partners__img-wrapper"
+          >
+            <img
+              alt="test img"
+              className="mfui-partners__tile-img"
+              src="/test-src"
+            />
+          </div>
+        </div>
+      </Tile>
+    </GridColumn>
+    <GridColumn
+      all="3"
+      key="2/test-src"
+      mobile="6"
+    >
+      <Tile
+        className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {
+              "data-testid": "item-test[3]",
+            },
+          }
+        }
+        href="#"
+        isInteractive={true}
+        shadowLevel="low"
+      >
+        <div
+          className="mfui-partners__tile-inner"
+        >
+          <div
+            className="mfui-partners__img-wrapper"
+          >
+            <img
+              alt="test img"
+              className="mfui-partners__tile-img"
+              src="/test-src"
+            />
+          </div>
+        </div>
+      </Tile>
+    </GridColumn>
+    <GridColumn
+      all="3"
+      key="3/test-src"
+      mobile="6"
+    >
+      <Tile
+        className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {
+              "data-testid": "item-test[4]",
+            },
+          }
+        }
+        href="#"
+        isInteractive={true}
+        shadowLevel="low"
+      >
+        <div
+          className="mfui-partners__tile-inner"
+        >
+          <div
+            className="mfui-partners__img-wrapper"
+          >
+            <img
+              alt="test img"
+              className="mfui-partners__tile-img"
+              src="/test-src"
+            />
+          </div>
+        </div>
+      </Tile>
+    </GridColumn>
+    <GridColumn
+      all="3"
+      key="4/test-src"
+      mobile="6"
+    >
+      <Tile
+        className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {
+              "data-testid": "item-test[5]",
+            },
+          }
+        }
+        href="#"
+        isInteractive={true}
+        shadowLevel="low"
+      >
+        <div
+          className="mfui-partners__tile-inner"
+        >
+          <div
+            className="mfui-partners__img-wrapper"
+          >
+            <img
+              alt="test img"
+              className="mfui-partners__tile-img"
+              src="/test-src"
+            />
+          </div>
+        </div>
+      </Tile>
+    </GridColumn>
+    <GridColumn
+      all="3"
+      key="5/test-src"
+      mobile="6"
+    >
+      <Tile
+        className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {
+              "data-testid": "item-test[6]",
+            },
+          }
+        }
+        href="#"
+        isInteractive={true}
+        shadowLevel="low"
+      >
+        <div
+          className="mfui-partners__tile-inner"
+        >
+          <div
+            className="mfui-partners__img-wrapper"
+          >
+            <img
+              alt="test img"
+              className="mfui-partners__tile-img"
+              src="/test-src"
+            />
+          </div>
+        </div>
+      </Tile>
+    </GridColumn>
+  </Grid>
+</div>
+`;
+
 exports[`<Partners /> should render carousel 1`] = `
 <div
   className="mfui-partners"
@@ -28,6 +239,11 @@ exports[`<Partners /> should render carousel 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -48,6 +264,11 @@ exports[`<Partners /> should render carousel 1`] = `
       </Tile>
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -73,6 +294,11 @@ exports[`<Partners /> should render carousel 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -93,6 +319,11 @@ exports[`<Partners /> should render carousel 1`] = `
       </Tile>
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -118,6 +349,11 @@ exports[`<Partners /> should render carousel 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -138,6 +374,11 @@ exports[`<Partners /> should render carousel 1`] = `
       </Tile>
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -163,6 +404,11 @@ exports[`<Partners /> should render carousel 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -183,6 +429,11 @@ exports[`<Partners /> should render carousel 1`] = `
       </Tile>
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -208,6 +459,11 @@ exports[`<Partners /> should render carousel 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -228,6 +484,11 @@ exports[`<Partners /> should render carousel 1`] = `
       </Tile>
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -253,6 +514,11 @@ exports[`<Partners /> should render carousel 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -273,6 +539,11 @@ exports[`<Partners /> should render carousel 1`] = `
       </Tile>
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -324,6 +595,11 @@ exports[`<Partners /> should render carousel with odd items number 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -344,6 +620,11 @@ exports[`<Partners /> should render carousel with odd items number 1`] = `
       </Tile>
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -369,6 +650,11 @@ exports[`<Partners /> should render carousel with odd items number 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -389,6 +675,11 @@ exports[`<Partners /> should render carousel with odd items number 1`] = `
       </Tile>
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -414,6 +705,11 @@ exports[`<Partners /> should render carousel with odd items number 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -434,6 +730,11 @@ exports[`<Partners /> should render carousel with odd items number 1`] = `
       </Tile>
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -459,6 +760,11 @@ exports[`<Partners /> should render carousel with odd items number 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -479,6 +785,11 @@ exports[`<Partners /> should render carousel with odd items number 1`] = `
       </Tile>
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -504,6 +815,11 @@ exports[`<Partners /> should render carousel with odd items number 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -524,6 +840,11 @@ exports[`<Partners /> should render carousel with odd items number 1`] = `
       </Tile>
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -549,6 +870,11 @@ exports[`<Partners /> should render carousel with odd items number 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -587,6 +913,11 @@ exports[`<Partners /> should render grid 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -613,6 +944,11 @@ exports[`<Partners /> should render grid 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -639,6 +975,11 @@ exports[`<Partners /> should render grid 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -665,6 +1006,11 @@ exports[`<Partners /> should render grid 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -703,6 +1049,11 @@ exports[`<Partners /> should render logotypes without href 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         isInteractive={false}
         shadowLevel="low"
       >
@@ -728,6 +1079,11 @@ exports[`<Partners /> should render logotypes without href 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         isInteractive={false}
         shadowLevel="low"
       >
@@ -753,6 +1109,11 @@ exports[`<Partners /> should render logotypes without href 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         isInteractive={false}
         shadowLevel="low"
       >
@@ -778,6 +1139,11 @@ exports[`<Partners /> should render logotypes without href 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         isInteractive={false}
         shadowLevel="low"
       >
@@ -815,6 +1181,11 @@ exports[`<Partners /> should render with classes props 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -841,6 +1212,11 @@ exports[`<Partners /> should render with classes props 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -867,6 +1243,11 @@ exports[`<Partners /> should render with classes props 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"
@@ -893,6 +1274,11 @@ exports[`<Partners /> should render with classes props 1`] = `
     >
       <Tile
         className="mfui-partners__tile"
+        dataAttrs={
+          Object {
+            "root": Object {},
+          }
+        }
         href="#"
         isInteractive={true}
         shadowLevel="low"

--- a/packages/ui-shared/src/components/Property/Property.test.tsx
+++ b/packages/ui-shared/src/components/Property/Property.test.tsx
@@ -135,7 +135,10 @@ describe('<Property />', () => {
         const wrapper = shallow(
             <Property
                 items={[{ title: ['Звонки на все номера России'], value: '500 ₽' }]}
-                dataAttrs={{ 'data-test': 'value' }}
+                dataAttrs={{
+                    root: { 'data-testid': 'root-test' },
+                    moreLink: { 'data-testid': 'moreLink-test' },
+                }}
             />,
         );
 

--- a/packages/ui-shared/src/components/Property/Property.tsx
+++ b/packages/ui-shared/src/components/Property/Property.tsx
@@ -26,8 +26,11 @@ export interface IProperty {
     icon?: React.ReactNode;
     /** Растягивание компонента на всю доступную ширину */
     fullWidth?: boolean;
-    /** Дата атрибуты для корневого элемента */
-    dataAttrs?: { [key: string]: string };
+    /** Дополнительные data атрибуты к внутренним элементам */
+    dataAttrs?: {
+        root?: Record<string, string>;
+        moreLink?: Record<string, string>;
+    };
     /** Дополнительные классы для внутренних элементов */
     classes?: {
         title?: string;
@@ -69,11 +72,12 @@ const Property: React.FC<IProperty> = ({
                     <PropertyDescription
                         value={value}
                         isCollapsible={isCollapsible}
+                        dataAttrs={{ moreLink: dataAttrs?.moreLink }}
                         classes={{ open: classes.openedDescription, toggle: classes.toggleDescription }}
                     />
                 </div>
             )),
-        [classes.openedDescription, classes.toggleDescription],
+        [classes.openedDescription, classes.toggleDescription, dataAttrs?.moreLink],
     );
 
     const getColumnConfig = React.useCallback(
@@ -86,7 +90,7 @@ const Property: React.FC<IProperty> = ({
         <div
             className={cn({ 'border-bottom': borderBottom }, [className])}
             ref={rootRef}
-            {...filterDataAttrs(dataAttrs)}
+            {...filterDataAttrs(dataAttrs?.root)}
         >
             <Grid>
                 <GridColumn {...getColumnConfig()}>
@@ -148,7 +152,10 @@ Property.propTypes = {
     mergedValue: PropTypes.string,
     icon: PropTypes.node,
     fullWidth: PropTypes.bool,
-    dataAttrs: PropTypes.objectOf(PropTypes.string.isRequired),
+    dataAttrs: PropTypes.shape({
+        root: PropTypes.objectOf(PropTypes.string.isRequired),
+        moreLink: PropTypes.objectOf(PropTypes.string.isRequired),
+    }),
     classes: PropTypes.shape({
         title: PropTypes.string,
         openedDescription: PropTypes.string,

--- a/packages/ui-shared/src/components/Property/PropertyDescription.test.tsx
+++ b/packages/ui-shared/src/components/Property/PropertyDescription.test.tsx
@@ -51,4 +51,16 @@ describe('<PropertyDescription />', () => {
 
         expect(wrapper.getDOMNode().classList.contains('open-custom-class')).toBeTruthy();
     });
+
+    it('should render with data attribute', () => {
+        const wrapper = shallow(
+            <PropertyDescription
+                value="Boom, Yandex.Музыка, Zvooq, ВКонтакте Музыка"
+                isCollapsible
+                dataAttrs={{ moreLink: { 'data-testid': 'moreLink-test' } }}
+            />,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/packages/ui-shared/src/components/Property/PropertyDescription.tsx
+++ b/packages/ui-shared/src/components/Property/PropertyDescription.tsx
@@ -2,13 +2,13 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import * as React from 'react';
 import { Collapse } from '@megafon/ui-core';
-import { cnCreate } from '@megafon/ui-helpers';
+import { cnCreate, filterDataAttrs } from '@megafon/ui-helpers';
 import PropTypes from 'prop-types';
 import './PropertyDescription.less';
 import { Desc } from './types';
 
 const cn = cnCreate('mfui-property-description');
-const PropertyDescription: React.FC<Desc> = ({ value, isCollapsible = false, classes = {} }) => {
+const PropertyDescription: React.FC<Desc> = ({ value, isCollapsible = false, classes = {}, dataAttrs }) => {
     const [isOpened, setIsOpened] = React.useState(false);
 
     const handleClickDesc = React.useCallback(() => setIsOpened(!isOpened), [isOpened]);
@@ -16,7 +16,11 @@ const PropertyDescription: React.FC<Desc> = ({ value, isCollapsible = false, cla
     if (isCollapsible) {
         return (
             <div className={cn([isOpened ? classes.open : undefined])}>
-                <span className={cn('collapse', classes.toggle)} onClick={handleClickDesc}>
+                <span
+                    onClick={handleClickDesc}
+                    {...filterDataAttrs(dataAttrs?.moreLink)}
+                    className={cn('collapse', classes.toggle)}
+                >
                     {isOpened ? 'Скрыть' : 'Подробнее'}
                 </span>
                 <Collapse className={cn('content')} classNameContainer={cn('content-inner')} isOpened={isOpened}>
@@ -35,6 +39,9 @@ PropertyDescription.propTypes = {
     classes: PropTypes.shape({
         open: PropTypes.string,
         toggle: PropTypes.string,
+    }),
+    dataAttrs: PropTypes.shape({
+        moreLink: PropTypes.objectOf(PropTypes.string.isRequired),
     }),
 };
 

--- a/packages/ui-shared/src/components/Property/__snapshots__/Property.test.tsx.snap
+++ b/packages/ui-shared/src/components/Property/__snapshots__/Property.test.tsx.snap
@@ -96,6 +96,11 @@ exports[`<Property /> should render title and description 1`] = `
                         "toggle": undefined,
                       }
                     }
+                    dataAttrs={
+                      Object {
+                        "moreLink": undefined,
+                      }
+                    }
                     value="Boom, Yandex.Музыка, Zvooq, ВКонтакте Музыка"
                   />
                 </div>
@@ -154,6 +159,11 @@ exports[`<Property /> should render title and hidden description 1`] = `
                       Object {
                         "open": undefined,
                         "toggle": undefined,
+                      }
+                    }
+                    dataAttrs={
+                      Object {
+                        "moreLink": undefined,
                       }
                     }
                     isCollapsible={true}
@@ -444,6 +454,11 @@ exports[`<Property /> should render with custom class names 1`] = `
                         "toggle": "toggle-description-custom-class",
                       }
                     }
+                    dataAttrs={
+                      Object {
+                        "moreLink": undefined,
+                      }
+                    }
                     isCollapsible={true}
                     value="Звонки на местные городские номера, когда вы находитесь дома, оплачиваются отдельно."
                   />
@@ -470,7 +485,7 @@ exports[`<Property /> should render with custom class names 1`] = `
 exports[`<Property /> should render with data attribute 1`] = `
 <div
   className="mfui-property"
-  data-test="value"
+  data-testid="root-test"
 >
   <Grid>
     <GridColumn
@@ -628,6 +643,11 @@ exports[`<Property /> should render with several descriptions 1`] = `
                         "toggle": undefined,
                       }
                     }
+                    dataAttrs={
+                      Object {
+                        "moreLink": undefined,
+                      }
+                    }
                     value="После израсходования пакета минут звонки на номера МегаФона России предоставляются безлимитно."
                   />
                 </div>
@@ -640,6 +660,11 @@ exports[`<Property /> should render with several descriptions 1`] = `
                       Object {
                         "open": undefined,
                         "toggle": undefined,
+                      }
+                    }
+                    dataAttrs={
+                      Object {
+                        "moreLink": undefined,
                       }
                     }
                     isCollapsible={true}

--- a/packages/ui-shared/src/components/Property/__snapshots__/PropertyDescription.test.tsx.snap
+++ b/packages/ui-shared/src/components/Property/__snapshots__/PropertyDescription.test.tsx.snap
@@ -67,3 +67,24 @@ exports[`<PropertyDescription /> should render with custom toggle class 1`] = `
   </Collapse>
 </div>
 `;
+
+exports[`<PropertyDescription /> should render with data attribute 1`] = `
+<div
+  className="mfui-property-description"
+>
+  <span
+    className="mfui-property-description__collapse"
+    data-testid="moreLink-test"
+    onClick={[Function]}
+  >
+    Подробнее
+  </span>
+  <Collapse
+    className="mfui-property-description__content"
+    classNameContainer="mfui-property-description__content-inner"
+    isOpened={false}
+  >
+    Boom, Yandex.Музыка, Zvooq, ВКонтакте Музыка
+  </Collapse>
+</div>
+`;

--- a/packages/ui-shared/src/components/Property/types.ts
+++ b/packages/ui-shared/src/components/Property/types.ts
@@ -7,6 +7,9 @@ export type Desc = {
         toggle?: string;
         open?: string;
     };
+    dataAttrs?: {
+        moreLink?: Record<string, string>;
+    };
 };
 
 export type Item = {

--- a/packages/ui-shared/src/components/StoreBanner/StoreBanner.test.tsx
+++ b/packages/ui-shared/src/components/StoreBanner/StoreBanner.test.tsx
@@ -9,7 +9,13 @@ const props: IStoreBannerProps = {
     linkGoogle: 'Google Play link',
     deviceMask: DeviceMask.ANDROID,
     imageSrc: 'image.png',
-    dataAttrs: { root: { 'data-root': 'value' } },
+    dataAttrs: {
+        root: { 'data-test-id': 'root-test' },
+        button: { 'data-test-id': 'button-test' },
+        linkApple: { 'data-test-id': 'linkApple-test' },
+        linkGoogle: { 'data-test-id': 'linkGoogle-test' },
+        linkHuawei: { 'data-test-id': 'linkHuawei-test' },
+    },
 };
 
 describe('StoreBanner', () => {

--- a/packages/ui-shared/src/components/StoreBanner/StoreBanner.tsx
+++ b/packages/ui-shared/src/components/StoreBanner/StoreBanner.tsx
@@ -20,8 +20,6 @@ export const DeviceMask = {
     WHITE_IPHONE: 'white-iphone',
 } as const;
 
-const DEFAULT_TEXT_BUTTON = 'Установите приложение';
-
 type DeviceMaskType = typeof DeviceMask[keyof typeof DeviceMask];
 
 type LinkHrefType = StoreButtonPropsType['href'];
@@ -88,10 +86,10 @@ const StoreBanner: React.FC<IStoreBannerProps> = ({
     linkGoogle,
     linkHuawei,
     linkButton,
-    textButton = DEFAULT_TEXT_BUTTON,
+    textButton = 'Установите приложение',
     qrCode,
     imageSrc,
-    theme = Theme.DEFAULT,
+    theme = 'default',
     deviceMask,
     rootRef,
     dataAttrs,

--- a/packages/ui-shared/src/components/StoreBanner/StoreBanner.tsx
+++ b/packages/ui-shared/src/components/StoreBanner/StoreBanner.tsx
@@ -68,6 +68,10 @@ export interface IStoreBannerProps {
     /** Дополнительные data атрибуты к внутренним элементам */
     dataAttrs?: {
         root?: Record<string, string>;
+        button?: Record<string, string>;
+        linkApple?: Record<string, string>;
+        linkGoogle?: Record<string, string>;
+        linkHuawei?: Record<string, string>;
     };
 }
 
@@ -119,6 +123,7 @@ const StoreBanner: React.FC<IStoreBannerProps> = ({
                                     <div className={cn('stores')}>
                                         {linkApple && (
                                             <StoreButton
+                                                dataAttrs={{ root: dataAttrs?.linkApple }}
                                                 theme={StoreButtonTheme.APP_STORE}
                                                 href={linkApple}
                                                 onClick={onClickApple}
@@ -127,6 +132,7 @@ const StoreBanner: React.FC<IStoreBannerProps> = ({
                                         )}
                                         {linkGoogle && (
                                             <StoreButton
+                                                dataAttrs={{ root: dataAttrs?.linkGoogle }}
                                                 theme={StoreButtonTheme.GOOGLE_PLAY}
                                                 href={linkGoogle}
                                                 className={cn(
@@ -139,6 +145,7 @@ const StoreBanner: React.FC<IStoreBannerProps> = ({
                                         )}
                                         {linkHuawei && (
                                             <StoreButton
+                                                dataAttrs={{ root: dataAttrs?.linkHuawei }}
                                                 theme={StoreButtonTheme.HUAWEI_STORE}
                                                 href={linkHuawei}
                                                 className={cn(
@@ -153,6 +160,7 @@ const StoreBanner: React.FC<IStoreBannerProps> = ({
                                 )}
                                 {linkButton && (
                                     <Button
+                                        dataAttrs={{ root: dataAttrs?.button }}
                                         className={cn('button')}
                                         href={linkButton}
                                         theme={theme === 'green' ? 'purple' : 'green'}
@@ -201,6 +209,10 @@ StoreBanner.propTypes = {
     theme: PropTypes.oneOf(Object.values(Theme)),
     dataAttrs: PropTypes.shape({
         root: PropTypes.objectOf(PropTypes.string.isRequired),
+        button: PropTypes.objectOf(PropTypes.string.isRequired),
+        linkApple: PropTypes.objectOf(PropTypes.string.isRequired),
+        linkGoogle: PropTypes.objectOf(PropTypes.string.isRequired),
+        linkHuawei: PropTypes.objectOf(PropTypes.string.isRequired),
     }),
 };
 

--- a/packages/ui-shared/src/components/StoreBanner/__snapshots__/StoreBanner.test.tsx.snap
+++ b/packages/ui-shared/src/components/StoreBanner/__snapshots__/StoreBanner.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`StoreBanner should render with Huawei Store 1`] = `
 <div
   className="mfui-store-banner mfui-store-banner_theme_default mfui-store-banner_mask_android custom-class-name"
-  data-root="value"
+  data-test-id="root-test"
 >
   <div
     className="mfui-store-banner__container"
@@ -42,16 +42,37 @@ exports[`StoreBanner should render with Huawei Store 1`] = `
               >
                 <StoreButton
                   className="mfui-store-banner__store-link mfui-store-banner__store-link_app-store"
+                  dataAttrs={
+                    Object {
+                      "root": Object {
+                        "data-test-id": "linkApple-test",
+                      },
+                    }
+                  }
                   href="App Store link"
                   theme="app-store"
                 />
                 <StoreButton
                   className="mfui-store-banner__store-link mfui-store-banner__store-link_google-play"
+                  dataAttrs={
+                    Object {
+                      "root": Object {
+                        "data-test-id": "linkGoogle-test",
+                      },
+                    }
+                  }
                   href="Google Play link"
                   theme="google-play"
                 />
                 <StoreButton
                   className="mfui-store-banner__store-link mfui-store-banner__store-link_huawei-store"
+                  dataAttrs={
+                    Object {
+                      "root": Object {
+                        "data-test-id": "linkHuawei-test",
+                      },
+                    }
+                  }
                   href="#huawei"
                   theme="huawei-store"
                 />
@@ -87,7 +108,7 @@ exports[`StoreBanner should render with Huawei Store 1`] = `
 exports[`StoreBanner should render with QR-code 1`] = `
 <div
   className="mfui-store-banner mfui-store-banner_theme_default mfui-store-banner_mask_android"
-  data-root="value"
+  data-test-id="root-test"
 >
   <div
     className="mfui-store-banner__container"
@@ -131,11 +152,25 @@ exports[`StoreBanner should render with QR-code 1`] = `
               >
                 <StoreButton
                   className="mfui-store-banner__store-link mfui-store-banner__store-link_app-store"
+                  dataAttrs={
+                    Object {
+                      "root": Object {
+                        "data-test-id": "linkApple-test",
+                      },
+                    }
+                  }
                   href="App Store link"
                   theme="app-store"
                 />
                 <StoreButton
                   className="mfui-store-banner__store-link mfui-store-banner__store-link_google-play"
+                  dataAttrs={
+                    Object {
+                      "root": Object {
+                        "data-test-id": "linkGoogle-test",
+                      },
+                    }
+                  }
                   href="Google Play link"
                   theme="google-play"
                 />
@@ -171,7 +206,7 @@ exports[`StoreBanner should render with QR-code 1`] = `
 exports[`StoreBanner should render with custom class names 1`] = `
 <div
   className="mfui-store-banner mfui-store-banner_theme_default mfui-store-banner_mask_android custom-class-name root-custom-class-name"
-  data-root="value"
+  data-test-id="root-test"
 >
   <div
     className="mfui-store-banner__container"
@@ -210,11 +245,25 @@ exports[`StoreBanner should render with custom class names 1`] = `
               >
                 <StoreButton
                   className="mfui-store-banner__store-link mfui-store-banner__store-link_app-store app-store-custom-class-name"
+                  dataAttrs={
+                    Object {
+                      "root": Object {
+                        "data-test-id": "linkApple-test",
+                      },
+                    }
+                  }
                   href="App Store link"
                   theme="app-store"
                 />
                 <StoreButton
                   className="mfui-store-banner__store-link mfui-store-banner__store-link_google-play google-store-custom-class-name"
+                  dataAttrs={
+                    Object {
+                      "root": Object {
+                        "data-test-id": "linkGoogle-test",
+                      },
+                    }
+                  }
                   href="Google Play link"
                   theme="google-play"
                 />
@@ -250,7 +299,7 @@ exports[`StoreBanner should render with custom class names 1`] = `
 exports[`StoreBanner should render with green button 1`] = `
 <div
   className="mfui-store-banner mfui-store-banner_theme_default mfui-store-banner_mask_android custom-class-name"
-  data-root="value"
+  data-test-id="root-test"
 >
   <div
     className="mfui-store-banner__container"
@@ -286,6 +335,13 @@ exports[`StoreBanner should render with green button 1`] = `
             >
               <Button
                 className="mfui-store-banner__button"
+                dataAttrs={
+                  Object {
+                    "root": Object {
+                      "data-test-id": "button-test",
+                    },
+                  }
+                }
                 href="#button"
                 theme="green"
               >
@@ -322,7 +378,7 @@ exports[`StoreBanner should render with green button 1`] = `
 exports[`StoreBanner should render with green theme 1`] = `
 <div
   className="mfui-store-banner mfui-store-banner_theme_green mfui-store-banner_mask_android"
-  data-root="value"
+  data-test-id="root-test"
 >
   <div
     className="mfui-store-banner__container"
@@ -361,11 +417,25 @@ exports[`StoreBanner should render with green theme 1`] = `
               >
                 <StoreButton
                   className="mfui-store-banner__store-link mfui-store-banner__store-link_app-store"
+                  dataAttrs={
+                    Object {
+                      "root": Object {
+                        "data-test-id": "linkApple-test",
+                      },
+                    }
+                  }
                   href="App Store link"
                   theme="app-store"
                 />
                 <StoreButton
                   className="mfui-store-banner__store-link mfui-store-banner__store-link_google-play"
+                  dataAttrs={
+                    Object {
+                      "root": Object {
+                        "data-test-id": "linkGoogle-test",
+                      },
+                    }
+                  }
                   href="Google Play link"
                   theme="google-play"
                 />
@@ -401,7 +471,7 @@ exports[`StoreBanner should render with green theme 1`] = `
 exports[`StoreBanner should render with iphone mask 1`] = `
 <div
   className="mfui-store-banner mfui-store-banner_theme_default mfui-store-banner_mask_black-iphone"
-  data-root="value"
+  data-test-id="root-test"
 >
   <div
     className="mfui-store-banner__container"
@@ -440,11 +510,25 @@ exports[`StoreBanner should render with iphone mask 1`] = `
               >
                 <StoreButton
                   className="mfui-store-banner__store-link mfui-store-banner__store-link_app-store"
+                  dataAttrs={
+                    Object {
+                      "root": Object {
+                        "data-test-id": "linkApple-test",
+                      },
+                    }
+                  }
                   href="App Store link"
                   theme="app-store"
                 />
                 <StoreButton
                   className="mfui-store-banner__store-link mfui-store-banner__store-link_google-play"
+                  dataAttrs={
+                    Object {
+                      "root": Object {
+                        "data-test-id": "linkGoogle-test",
+                      },
+                    }
+                  }
                   href="Google Play link"
                   theme="google-play"
                 />
@@ -480,7 +564,7 @@ exports[`StoreBanner should render with iphone mask 1`] = `
 exports[`StoreBanner should render with required props 1`] = `
 <div
   className="mfui-store-banner mfui-store-banner_theme_default mfui-store-banner_mask_android"
-  data-root="value"
+  data-test-id="root-test"
 >
   <div
     className="mfui-store-banner__container"
@@ -519,11 +603,25 @@ exports[`StoreBanner should render with required props 1`] = `
               >
                 <StoreButton
                   className="mfui-store-banner__store-link mfui-store-banner__store-link_app-store"
+                  dataAttrs={
+                    Object {
+                      "root": Object {
+                        "data-test-id": "linkApple-test",
+                      },
+                    }
+                  }
                   href="App Store link"
                   theme="app-store"
                 />
                 <StoreButton
                   className="mfui-store-banner__store-link mfui-store-banner__store-link_google-play"
+                  dataAttrs={
+                    Object {
+                      "root": Object {
+                        "data-test-id": "linkGoogle-test",
+                      },
+                    }
+                  }
                   href="Google Play link"
                   theme="google-play"
                 />
@@ -559,7 +657,7 @@ exports[`StoreBanner should render with required props 1`] = `
 exports[`StoreBanner should render with violet button 1`] = `
 <div
   className="mfui-store-banner mfui-store-banner_theme_green mfui-store-banner_mask_android custom-class-name"
-  data-root="value"
+  data-test-id="root-test"
 >
   <div
     className="mfui-store-banner__container"
@@ -595,6 +693,13 @@ exports[`StoreBanner should render with violet button 1`] = `
             >
               <Button
                 className="mfui-store-banner__button"
+                dataAttrs={
+                  Object {
+                    "root": Object {
+                      "data-test-id": "button-test",
+                    },
+                  }
+                }
                 href="#button"
                 theme="purple"
               >

--- a/packages/ui-shared/src/components/StoreButton/StoreButton.test.tsx
+++ b/packages/ui-shared/src/components/StoreButton/StoreButton.test.tsx
@@ -30,6 +30,12 @@ describe('StoreButton', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    it('should render with data-attributes', () => {
+        const wrapper = shallow(<StoreButton {...props} dataAttrs={{ root: { 'data-test-id': 'root-test' } }} />);
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
     it('should call click handler', () => {
         const onClick = jest.fn();
         const wrapper = shallow(<StoreButton {...props} onClick={onClick} />);

--- a/packages/ui-shared/src/components/StoreButton/StoreButton.tsx
+++ b/packages/ui-shared/src/components/StoreButton/StoreButton.tsx
@@ -13,7 +13,7 @@ export enum Theme {
 type LinkPropTypes = React.ComponentProps<typeof Link>;
 
 export type Props = Required<Pick<LinkPropTypes, 'href'>> &
-    Pick<LinkPropTypes, 'onClick'> & {
+    Pick<LinkPropTypes, 'onClick' | 'dataAttrs'> & {
         /** Тема кнопки */
         theme: Theme;
         /** Дополнительный класс */
@@ -21,8 +21,8 @@ export type Props = Required<Pick<LinkPropTypes, 'href'>> &
     };
 
 const cn = cnCreate('mfui-store-button');
-const StoreButton: React.FC<Props> = ({ href, onClick, theme, className }) => (
-    <Link href={href} onClick={onClick} className={cn({ theme }, className)} />
+const StoreButton: React.FC<Props> = ({ href, onClick, theme, className, ...rest }) => (
+    <Link {...rest} href={href} onClick={onClick} className={cn({ theme }, className)} />
 );
 
 StoreButton.propTypes = {

--- a/packages/ui-shared/src/components/StoreButton/__snapshots__/StoreButton.test.tsx.snap
+++ b/packages/ui-shared/src/components/StoreButton/__snapshots__/StoreButton.test.tsx.snap
@@ -20,3 +20,17 @@ exports[`StoreButton should render with custom class name 1`] = `
   href="href"
 />
 `;
+
+exports[`StoreButton should render with data-attributes 1`] = `
+<Link
+  className="mfui-store-button mfui-store-button_theme_app-store"
+  dataAttrs={
+    Object {
+      "root": Object {
+        "data-test-id": "root-test",
+      },
+    }
+  }
+  href="href"
+/>
+`;

--- a/packages/ui-shared/src/components/Table/Table.less
+++ b/packages/ui-shared/src/components/Table/Table.less
@@ -146,7 +146,7 @@
         height: 72px;
         padding-bottom: 12px;
 
-        color: var(--stcBlack5);
+        color: var(--spbSky3);
         vertical-align: bottom;
 
         background-color: var(--spbSky0);

--- a/packages/ui-shared/src/components/TextWithIcon/TextWithIconItem.tsx
+++ b/packages/ui-shared/src/components/TextWithIcon/TextWithIconItem.tsx
@@ -5,7 +5,7 @@ import './TextWithIconItem.less';
 
 export interface ITextWithIconItem {
     /** Текст */
-    text: string;
+    text: string | string[];
     /** Иконка */
     icon: React.ReactNode;
     /** Ссылка на корневой элемент */
@@ -27,7 +27,7 @@ const TextWithIconItem: React.FC<ITextWithIconItem> = ({ text, icon, rootRef, da
 );
 
 TextWithIconItem.propTypes = {
-    text: PropTypes.string.isRequired,
+    text: PropTypes.oneOfType([PropTypes.string.isRequired, PropTypes.arrayOf(PropTypes.string.isRequired)]).isRequired,
     icon: PropTypes.node.isRequired,
     rootRef: PropTypes.oneOfType([
         PropTypes.func,

--- a/packages/ui-shared/src/components/TextWithIcon/doc/TextWithIcon.example.mdx
+++ b/packages/ui-shared/src/components/TextWithIcon/doc/TextWithIcon.example.mdx
@@ -9,7 +9,7 @@ import Heart from '@megafon/ui-icons/basic-16-heart_16.svg';
 
 <Playground>
     <TextWithIcon>
-        <TextWithIconItem text="Привлечение новых клиентов и повышение лояльности действующих" icon={<Heart style={{ fill: '#00B956' }} />} />
+        <TextWithIconItem text={["Привлечение новых клиентов и повышение лояльности действующих"]} icon={<Heart style={{ fill: '#00B956' }} />} />
         <TextWithIconItem text="Специальные предложения для ваших клиентов" icon={<Star style={{ fill: '#00B956' }} />} />
         <TextWithIconItem text="Понятная и простая реализация партнерстваих" icon={<Like style={{ fill: '#00B956' }} />} />
     </TextWithIcon>

--- a/packages/ui-shared/src/components/VideoBanner/VideoBanner.test.tsx
+++ b/packages/ui-shared/src/components/VideoBanner/VideoBanner.test.tsx
@@ -123,10 +123,20 @@ describe('<VideoBanner />', () => {
 
     it('render component with dataAttrs', () => {
         const wrapper = shallow(
-            <VideoBanner imageMobile={imageMobile} imageTablet={imageTablet} dataAttrs={{ 'data-test': 'value' }} />,
+            <VideoBanner
+                imageMobile={imageMobile}
+                imageTablet={imageTablet}
+                dataAttrs={{
+                    root: { 'data-testid': 'root-test' },
+                    breadcrumbs: { 'data-testid': 'breadcrumbs-test' },
+                    breadcrumbsLink: { 'data-testid': 'breadcrumbsLink-test' },
+                    button: { 'data-testid': 'button-test' },
+                    link: { 'data-testid': 'link-test' },
+                }}
+            />,
         );
 
-        expect(wrapper.first().prop('data-test')).toEqual('value');
+        expect(wrapper).toMatchSnapshot();
     });
 
     it('render component with pictures and non default content text color', () => {

--- a/packages/ui-shared/src/components/VideoBanner/VideoBanner.test.tsx
+++ b/packages/ui-shared/src/components/VideoBanner/VideoBanner.test.tsx
@@ -299,6 +299,24 @@ describe('<VideoBanner />', () => {
             expect(wrapper).toMatchSnapshot();
         });
 
+        it('render component with classes for video', () => {
+            localWindow.innerWidth = 1920;
+            const wrapper = mount(
+                <VideoBanner
+                    imageMobile={imageMobile}
+                    imageTablet={imageTablet}
+                    videoType={VideoType.VIDEO}
+                    videoSrc={video}
+                    content={content}
+                    classes={{
+                        video: 'videoClass',
+                    }}
+                />,
+            );
+
+            expect(wrapper).toMatchSnapshot();
+        });
+
         it('render video with sounds enabled', () => {
             localWindow.innerWidth = 1920;
             const wrapper = mount(

--- a/packages/ui-shared/src/components/VideoBanner/VideoBanner.tsx
+++ b/packages/ui-shared/src/components/VideoBanner/VideoBanner.tsx
@@ -79,8 +79,14 @@ export interface IContent {
 }
 
 interface IVideoBannerProps {
-    /** Дата атрибуты для корневого элемента */
-    dataAttrs?: { [key: string]: string };
+    /** Дополнительные data атрибуты к внутренним элементам */
+    dataAttrs?: {
+        root?: Record<string, string>;
+        breadcrumbs?: Record<string, string>;
+        breadcrumbsLink?: Record<string, string>;
+        button?: Record<string, string>;
+        link?: Record<string, string>;
+    };
     /** Дополнительный класс корневого элемента */
     className?: string;
     /** Дополнительные классы для корневого и внутренних элементов */
@@ -170,6 +176,7 @@ const VideoBanner: React.FC<IVideoBannerProps> = ({
                         <div className={cn('btns-wrapper')}>
                             {buttonTitle && (
                                 <Button
+                                    dataAttrs={{ root: dataAttrs?.button }}
                                     className={cn(ClassName.BUTTON, [classes.button])}
                                     theme={buttonColor}
                                     href={buttonHref}
@@ -181,6 +188,7 @@ const VideoBanner: React.FC<IVideoBannerProps> = ({
                             )}
                             {linkTitle && (
                                 <TextLink
+                                    dataAttrs={{ root: dataAttrs?.link }}
                                     className={cn(ClassName.LINK, [classes.link])}
                                     href={linkUrl}
                                     download={linkDownload}
@@ -194,7 +202,7 @@ const VideoBanner: React.FC<IVideoBannerProps> = ({
                 </GridColumn>
             </Grid>
         ),
-        [classes.button, classes.link],
+        [classes.button, classes.link, dataAttrs?.button, dataAttrs?.link],
     );
 
     const renderVideo = React.useCallback(() => {
@@ -270,11 +278,12 @@ const VideoBanner: React.FC<IVideoBannerProps> = ({
     }, [imageDesktop, imageDesktopWide, imageMobile, imageTablet]);
 
     return (
-        <div {...filterDataAttrs(dataAttrs)} className={cn([className, classes.root])} ref={rootRef}>
+        <div {...filterDataAttrs(dataAttrs?.root)} className={cn([className, classes.root])} ref={rootRef}>
             <ContentArea>
                 <div className={cn('wrapper')}>
                     {!!breadcrumbs?.length && (
                         <Breadcrumbs
+                            dataAttrs={{ root: dataAttrs?.breadcrumbs, link: dataAttrs?.breadcrumbsLink }}
                             className={cn('breadcrumbs')}
                             items={breadcrumbs}
                             color={content?.textColor}
@@ -293,7 +302,13 @@ const VideoBanner: React.FC<IVideoBannerProps> = ({
 };
 
 VideoBanner.propTypes = {
-    dataAttrs: PropTypes.objectOf(PropTypes.string.isRequired),
+    dataAttrs: PropTypes.shape({
+        root: PropTypes.objectOf(PropTypes.string.isRequired),
+        breadcrumbs: PropTypes.objectOf(PropTypes.string.isRequired),
+        breadcrumbsLink: PropTypes.objectOf(PropTypes.string.isRequired),
+        button: PropTypes.objectOf(PropTypes.string.isRequired),
+        link: PropTypes.objectOf(PropTypes.string.isRequired),
+    }),
     className: PropTypes.string,
     classes: PropTypes.shape({
         root: PropTypes.string,

--- a/packages/ui-shared/src/components/VideoBanner/VideoBanner.tsx
+++ b/packages/ui-shared/src/components/VideoBanner/VideoBanner.tsx
@@ -89,6 +89,7 @@ interface IVideoBannerProps {
         button?: string;
         link?: string;
         breadcrumbs?: string;
+        video?: string;
     };
     /** Ссылка на корневой элемент */
     rootRef?: Ref<HTMLDivElement>;
@@ -227,7 +228,7 @@ const VideoBanner: React.FC<IVideoBannerProps> = ({
             case VideoType.VIDEO: {
                 return (
                     // eslint-disable-next-line jsx-a11y/media-has-caption
-                    <video className={cn('video')} autoPlay loop muted={isMuted}>
+                    <video className={cn('video', [classes.video])} autoPlay loop muted={isMuted}>
                         <source src={videoSrc} type="video/mp4" />
                     </video>
                 );
@@ -237,7 +238,7 @@ const VideoBanner: React.FC<IVideoBannerProps> = ({
                 return null;
             }
         }
-    }, [videoType, videoSrc, isMuted]);
+    }, [videoType, videoSrc, isMuted, classes.video]);
 
     React.useEffect(() => {
         const getImageSrc = () => {

--- a/packages/ui-shared/src/components/VideoBanner/__snapshots__/VideoBanner.test.tsx.snap
+++ b/packages/ui-shared/src/components/VideoBanner/__snapshots__/VideoBanner.test.tsx.snap
@@ -15,6 +15,12 @@ exports[`<VideoBanner /> render component with breadcrumbs 1`] = `
             "item": "breadcrumbs-item-custom-class-name",
           }
         }
+        dataAttrs={
+          Object {
+            "link": undefined,
+            "root": undefined,
+          }
+        }
         items={
           Array [
             Object {
@@ -79,6 +85,11 @@ exports[`<VideoBanner /> render component with breadcrumbs 1`] = `
             >
               <Button
                 className="mfui-video-banner__button"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="#"
                 theme="green"
               >
@@ -86,6 +97,11 @@ exports[`<VideoBanner /> render component with breadcrumbs 1`] = `
               </Button>
               <TextLink
                 className="mfui-video-banner__link"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="#"
               >
                 Личный кабинет услуги
@@ -162,6 +178,11 @@ exports[`<VideoBanner /> render component with classes 1`] = `
             >
               <Button
                 className="mfui-video-banner__button buttonClass"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="#"
                 theme="green"
               >
@@ -169,6 +190,11 @@ exports[`<VideoBanner /> render component with classes 1`] = `
               </Button>
               <TextLink
                 className="mfui-video-banner__link linkClass"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="#"
               >
                 Личный кабинет услуги
@@ -177,6 +203,28 @@ exports[`<VideoBanner /> render component with classes 1`] = `
           </div>
         </GridColumn>
       </Grid>
+      <div
+        className="mfui-video-banner__background-image"
+        style={
+          Object {
+            "backgroundImage": "url(imageMobile)",
+          }
+        }
+      />
+    </div>
+  </ContentArea>
+</div>
+`;
+
+exports[`<VideoBanner /> render component with dataAttrs 1`] = `
+<div
+  className="mfui-video-banner"
+  data-testid="root-test"
+>
+  <ContentArea>
+    <div
+      className="mfui-video-banner__wrapper"
+    >
       <div
         className="mfui-video-banner__background-image"
         style={
@@ -245,6 +293,11 @@ exports[`<VideoBanner /> render component with non default buttonColor 1`] = `
             >
               <Button
                 className="mfui-video-banner__button"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="#"
                 theme="purple"
               >
@@ -252,6 +305,11 @@ exports[`<VideoBanner /> render component with non default buttonColor 1`] = `
               </Button>
               <TextLink
                 className="mfui-video-banner__link"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="#"
               >
                 Личный кабинет услуги
@@ -349,6 +407,11 @@ exports[`<VideoBanner /> render component with pictures and content 1`] = `
             >
               <Button
                 className="mfui-video-banner__button"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="#"
                 theme="green"
               >
@@ -356,6 +419,11 @@ exports[`<VideoBanner /> render component with pictures and content 1`] = `
               </Button>
               <TextLink
                 className="mfui-video-banner__link"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="#"
               >
                 Личный кабинет услуги
@@ -432,6 +500,11 @@ exports[`<VideoBanner /> render component with pictures and download links conte
             >
               <Button
                 className="mfui-video-banner__button"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 download={true}
                 href="#"
                 theme="green"
@@ -440,6 +513,11 @@ exports[`<VideoBanner /> render component with pictures and download links conte
               </Button>
               <TextLink
                 className="mfui-video-banner__link"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 download={true}
                 href="#"
               >
@@ -517,6 +595,11 @@ exports[`<VideoBanner /> render component with pictures and non default content 
             >
               <Button
                 className="mfui-video-banner__button"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="#"
                 theme="green"
               >
@@ -524,6 +607,11 @@ exports[`<VideoBanner /> render component with pictures and non default content 
               </Button>
               <TextLink
                 className="mfui-video-banner__link"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="#"
               >
                 Личный кабинет услуги
@@ -600,6 +688,11 @@ exports[`<VideoBanner /> render component with the different content text color 
             >
               <Button
                 className="mfui-video-banner__button"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="#"
                 theme="green"
               >
@@ -607,6 +700,11 @@ exports[`<VideoBanner /> render component with the different content text color 
               </Button>
               <TextLink
                 className="mfui-video-banner__link"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="#"
               >
                 Личный кабинет услуги
@@ -683,6 +781,11 @@ exports[`<VideoBanner /> render component without button 1`] = `
             >
               <TextLink
                 className="mfui-video-banner__link"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
                 href="#"
               >
                 Личный кабинет услуги
@@ -816,6 +919,11 @@ exports[`<VideoBanner /> tests with local window render component with classes f
                         >
                           <Button
                             className="mfui-video-banner__button"
+                            dataAttrs={
+                              Object {
+                                "root": undefined,
+                              }
+                            }
                             href="#"
                             theme="green"
                           >
@@ -842,10 +950,20 @@ exports[`<VideoBanner /> tests with local window render component with classes f
                           </Button>
                           <TextLink
                             className="mfui-video-banner__link"
+                            dataAttrs={
+                              Object {
+                                "root": undefined,
+                              }
+                            }
                             href="#"
                           >
                             <Link
                               className="mfui-text-link mfui-text-link_underline-visibility_hover mfui-text-link_underline-style_solid mfui-text-link_color_blue mfui-video-banner__link"
+                              dataAttrs={
+                                Object {
+                                  "root": undefined,
+                                }
+                              }
                               href="#"
                             >
                               <a
@@ -1212,6 +1330,11 @@ exports[`<VideoBanner /> tests with local window render with video and content 1
                         >
                           <Button
                             className="mfui-video-banner__button"
+                            dataAttrs={
+                              Object {
+                                "root": undefined,
+                              }
+                            }
                             href="#"
                             theme="green"
                           >
@@ -1238,10 +1361,20 @@ exports[`<VideoBanner /> tests with local window render with video and content 1
                           </Button>
                           <TextLink
                             className="mfui-video-banner__link"
+                            dataAttrs={
+                              Object {
+                                "root": undefined,
+                              }
+                            }
                             href="#"
                           >
                             <Link
                               className="mfui-text-link mfui-text-link_underline-visibility_hover mfui-text-link_underline-style_solid mfui-text-link_color_blue mfui-video-banner__link"
+                              dataAttrs={
+                                Object {
+                                  "root": undefined,
+                                }
+                              }
                               href="#"
                             >
                               <a

--- a/packages/ui-shared/src/components/VideoBanner/__snapshots__/VideoBanner.test.tsx.snap
+++ b/packages/ui-shared/src/components/VideoBanner/__snapshots__/VideoBanner.test.tsx.snap
@@ -755,6 +755,190 @@ exports[`<VideoBanner /> render component without button 1`] = `
 </div>
 `;
 
+exports[`<VideoBanner /> tests with local window render component with classes for video 1`] = `
+<VideoBanner
+  classes={
+    Object {
+      "video": "videoClass",
+    }
+  }
+  content={
+    Object {
+      "buttonHref": "#",
+      "buttonTitle": "Текст в кнопке",
+      "cost": "oт <b>1000 ₽</b> за сообщение",
+      "description": "Описание должно быть примерно не более 130 символов. Пишите содержательно, кратно и не будет проблем с текстовым контентом.",
+      "linkTitle": "Личный кабинет услуги",
+      "linkUrl": "#",
+      "title": "Текст ≈40 симовлов. Короткие слова",
+    }
+  }
+  imageMobile="imageMobile"
+  imageTablet="imageTablet"
+  videoSrc="video.mp4"
+  videoType="video"
+>
+  <div
+    className="mfui-video-banner"
+  >
+    <ContentArea
+      innerBackgroundColor="transparent"
+      outerBackgroundColor="transparent"
+    >
+      <div
+        className="mfui-content-area mfui-content-area_color_transparent"
+      >
+        <div
+          className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+        >
+          <div
+            className="mfui-video-banner__wrapper"
+          >
+            <Grid
+              className="mfui-video-banner__grid"
+              guttersLeft="medium"
+            >
+              <div
+                className="mfui-grid mfui-video-banner__grid"
+              >
+                <div
+                  className="mfui-grid__container mfui-grid__container_multi-row mfui-grid__container_gutters-left_medium"
+                >
+                  <GridColumn
+                    className="mfui-grid__column mfui-grid__column_gutter-left_medium"
+                    desktop="7"
+                    key=".0"
+                    mobile="12"
+                    tablet="7"
+                    wide="6"
+                  >
+                    <div
+                      className="mfui-grid-column mfui-grid-column_all_12 mfui-grid-column_wide_6 mfui-grid-column_desktop_7 mfui-grid-column_tablet_7 mfui-grid-column_mobile_12 mfui-grid-column_all-order_0 mfui-grid-column_wide-order_0 mfui-grid-column_desktop-order_0 mfui-grid-column_tablet-order_0 mfui-grid-column_mobile-order_0 mfui-grid__column mfui-grid__column_gutter-left_medium"
+                    >
+                      <div
+                        className="mfui-video-banner__content mfui-video-banner__content_text-color_black"
+                      >
+                        <Header
+                          as="h1"
+                          className="mfui-video-banner__title"
+                          color="inherit"
+                        >
+                          <h1
+                            className="mfui-header mfui-header_color_inherit mfui-header_level_h1 mfui-header_h-align_inherit mfui-video-banner__title"
+                          >
+                            Текст ≈40 симовлов. Короткие слова
+                          </h1>
+                        </Header>
+                        <div
+                          className="mfui-video-banner__text"
+                        >
+                          <Header
+                            as="h5"
+                            className="mfui-video-banner__description"
+                            color="inherit"
+                          >
+                            <h5
+                              className="mfui-header mfui-header_color_inherit mfui-header_level_h5 mfui-header_h-align_inherit mfui-video-banner__description"
+                            >
+                              Описание должно быть примерно не более 130 символов. Пишите содержательно, кратно и не будет проблем с текстовым контентом.
+                            </h5>
+                          </Header>
+                          <div
+                            className="mfui-video-banner__cost"
+                          >
+                            oт 
+                            <component
+                              key="1"
+                            >
+                              <Header
+                                as="h3"
+                                className="mfui-video-banner__value"
+                                color="inherit"
+                              >
+                                <h3
+                                  className="mfui-header mfui-header_color_inherit mfui-header_level_h3 mfui-header_h-align_inherit mfui-video-banner__value"
+                                >
+                                  1000 ₽
+                                </h3>
+                              </Header>
+                            </component>
+                             за сообщение
+                          </div>
+                        </div>
+                        <div
+                          className="mfui-video-banner__btns-wrapper"
+                        >
+                          <Button
+                            className="mfui-video-banner__button"
+                            href="#"
+                            theme="green"
+                          >
+                            <a
+                              className="mfui-button mfui-button_type_primary mfui-button_theme_green mfui-button_size-all_medium mfui-button_no-touch mfui-button_content-type_text mfui-video-banner__button"
+                              disabled={false}
+                              href="#"
+                              onClick={[Function]}
+                            >
+                              <div
+                                className="mfui-button__inner"
+                              >
+                                <div
+                                  className="mfui-button__content"
+                                >
+                                  <span
+                                    className="mfui-button__text"
+                                  >
+                                    Текст в кнопке
+                                  </span>
+                                </div>
+                              </div>
+                            </a>
+                          </Button>
+                          <TextLink
+                            className="mfui-video-banner__link"
+                            color="blue"
+                            href="#"
+                            underlineStyle="solid"
+                            underlineVisibility="hover"
+                          >
+                            <Link
+                              className="mfui-text-link mfui-text-link_underline-visibility_hover mfui-text-link_underline-style_solid mfui-text-link_color_blue mfui-video-banner__link"
+                              href="#"
+                            >
+                              <a
+                                className="mfui-text-link mfui-text-link_underline-visibility_hover mfui-text-link_underline-style_solid mfui-text-link_color_blue mfui-video-banner__link"
+                                href="#"
+                              >
+                                Личный кабинет услуги
+                              </a>
+                            </Link>
+                          </TextLink>
+                        </div>
+                      </div>
+                    </div>
+                  </GridColumn>
+                </div>
+              </div>
+            </Grid>
+            <video
+              autoPlay={true}
+              className="mfui-video-banner__video videoClass"
+              loop={true}
+              muted={true}
+            >
+              <source
+                src="video.mp4"
+                type="video/mp4"
+              />
+            </video>
+          </div>
+        </div>
+      </div>
+    </ContentArea>
+  </div>
+</VideoBanner>
+`;
+
 exports[`<VideoBanner /> tests with local window render desktop image on relevant resolution 1`] = `
 <VideoBanner
   imageDesktop="imageDesktop"

--- a/packages/ui-shared/src/components/VideoBanner/__snapshots__/VideoBanner.test.tsx.snap
+++ b/packages/ui-shared/src/components/VideoBanner/__snapshots__/VideoBanner.test.tsx.snap
@@ -4,10 +4,7 @@ exports[`<VideoBanner /> render component with breadcrumbs 1`] = `
 <div
   className="mfui-video-banner"
 >
-  <ContentArea
-    innerBackgroundColor="transparent"
-    outerBackgroundColor="transparent"
-  >
+  <ContentArea>
     <div
       className="mfui-video-banner__wrapper"
     >
@@ -89,10 +86,7 @@ exports[`<VideoBanner /> render component with breadcrumbs 1`] = `
               </Button>
               <TextLink
                 className="mfui-video-banner__link"
-                color="blue"
                 href="#"
-                underlineStyle="solid"
-                underlineVisibility="hover"
               >
                 Личный кабинет услуги
               </TextLink>
@@ -117,10 +111,7 @@ exports[`<VideoBanner /> render component with classes 1`] = `
 <div
   className="mfui-video-banner className rootClass"
 >
-  <ContentArea
-    innerBackgroundColor="transparent"
-    outerBackgroundColor="transparent"
-  >
+  <ContentArea>
     <div
       className="mfui-video-banner__wrapper"
     >
@@ -178,10 +169,7 @@ exports[`<VideoBanner /> render component with classes 1`] = `
               </Button>
               <TextLink
                 className="mfui-video-banner__link linkClass"
-                color="blue"
                 href="#"
-                underlineStyle="solid"
-                underlineVisibility="hover"
               >
                 Личный кабинет услуги
               </TextLink>
@@ -206,10 +194,7 @@ exports[`<VideoBanner /> render component with non default buttonColor 1`] = `
 <div
   className="mfui-video-banner"
 >
-  <ContentArea
-    innerBackgroundColor="transparent"
-    outerBackgroundColor="transparent"
-  >
+  <ContentArea>
     <div
       className="mfui-video-banner__wrapper"
     >
@@ -267,10 +252,7 @@ exports[`<VideoBanner /> render component with non default buttonColor 1`] = `
               </Button>
               <TextLink
                 className="mfui-video-banner__link"
-                color="blue"
                 href="#"
-                underlineStyle="solid"
-                underlineVisibility="hover"
               >
                 Личный кабинет услуги
               </TextLink>
@@ -295,10 +277,7 @@ exports[`<VideoBanner /> render component with pictures 1`] = `
 <div
   className="mfui-video-banner"
 >
-  <ContentArea
-    innerBackgroundColor="transparent"
-    outerBackgroundColor="transparent"
-  >
+  <ContentArea>
     <div
       className="mfui-video-banner__wrapper"
     >
@@ -319,10 +298,7 @@ exports[`<VideoBanner /> render component with pictures and content 1`] = `
 <div
   className="mfui-video-banner"
 >
-  <ContentArea
-    innerBackgroundColor="transparent"
-    outerBackgroundColor="transparent"
-  >
+  <ContentArea>
     <div
       className="mfui-video-banner__wrapper"
     >
@@ -380,10 +356,7 @@ exports[`<VideoBanner /> render component with pictures and content 1`] = `
               </Button>
               <TextLink
                 className="mfui-video-banner__link"
-                color="blue"
                 href="#"
-                underlineStyle="solid"
-                underlineVisibility="hover"
               >
                 Личный кабинет услуги
               </TextLink>
@@ -408,10 +381,7 @@ exports[`<VideoBanner /> render component with pictures and download links conte
 <div
   className="mfui-video-banner"
 >
-  <ContentArea
-    innerBackgroundColor="transparent"
-    outerBackgroundColor="transparent"
-  >
+  <ContentArea>
     <div
       className="mfui-video-banner__wrapper"
     >
@@ -470,11 +440,8 @@ exports[`<VideoBanner /> render component with pictures and download links conte
               </Button>
               <TextLink
                 className="mfui-video-banner__link"
-                color="blue"
                 download={true}
                 href="#"
-                underlineStyle="solid"
-                underlineVisibility="hover"
               >
                 Личный кабинет услуги
               </TextLink>
@@ -499,10 +466,7 @@ exports[`<VideoBanner /> render component with pictures and non default content 
 <div
   className="mfui-video-banner"
 >
-  <ContentArea
-    innerBackgroundColor="transparent"
-    outerBackgroundColor="transparent"
-  >
+  <ContentArea>
     <div
       className="mfui-video-banner__wrapper"
     >
@@ -560,10 +524,7 @@ exports[`<VideoBanner /> render component with pictures and non default content 
               </Button>
               <TextLink
                 className="mfui-video-banner__link"
-                color="blue"
                 href="#"
-                underlineStyle="solid"
-                underlineVisibility="hover"
               >
                 Личный кабинет услуги
               </TextLink>
@@ -588,10 +549,7 @@ exports[`<VideoBanner /> render component with the different content text color 
 <div
   className="mfui-video-banner"
 >
-  <ContentArea
-    innerBackgroundColor="transparent"
-    outerBackgroundColor="transparent"
-  >
+  <ContentArea>
     <div
       className="mfui-video-banner__wrapper"
     >
@@ -649,10 +607,7 @@ exports[`<VideoBanner /> render component with the different content text color 
               </Button>
               <TextLink
                 className="mfui-video-banner__link"
-                color="blue"
                 href="#"
-                underlineStyle="solid"
-                underlineVisibility="hover"
               >
                 Личный кабинет услуги
               </TextLink>
@@ -677,10 +632,7 @@ exports[`<VideoBanner /> render component without button 1`] = `
 <div
   className="mfui-video-banner"
 >
-  <ContentArea
-    innerBackgroundColor="transparent"
-    outerBackgroundColor="transparent"
-  >
+  <ContentArea>
     <div
       className="mfui-video-banner__wrapper"
     >
@@ -731,10 +683,7 @@ exports[`<VideoBanner /> render component without button 1`] = `
             >
               <TextLink
                 className="mfui-video-banner__link"
-                color="blue"
                 href="#"
-                underlineStyle="solid"
-                underlineVisibility="hover"
               >
                 Личный кабинет услуги
               </TextLink>
@@ -781,15 +730,12 @@ exports[`<VideoBanner /> tests with local window render component with classes f
   <div
     className="mfui-video-banner"
   >
-    <ContentArea
-      innerBackgroundColor="transparent"
-      outerBackgroundColor="transparent"
-    >
+    <ContentArea>
       <div
-        className="mfui-content-area mfui-content-area_color_transparent"
+        className="mfui-content-area mfui-content-area_background-color_transparent"
       >
         <div
-          className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+          className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
         >
           <div
             className="mfui-video-banner__wrapper"
@@ -896,10 +842,7 @@ exports[`<VideoBanner /> tests with local window render component with classes f
                           </Button>
                           <TextLink
                             className="mfui-video-banner__link"
-                            color="blue"
                             href="#"
-                            underlineStyle="solid"
-                            underlineVisibility="hover"
                           >
                             <Link
                               className="mfui-text-link mfui-text-link_underline-visibility_hover mfui-text-link_underline-style_solid mfui-text-link_color_blue mfui-video-banner__link"
@@ -949,15 +892,12 @@ exports[`<VideoBanner /> tests with local window render desktop image on relevan
   <div
     className="mfui-video-banner"
   >
-    <ContentArea
-      innerBackgroundColor="transparent"
-      outerBackgroundColor="transparent"
-    >
+    <ContentArea>
       <div
-        className="mfui-content-area mfui-content-area_color_transparent"
+        className="mfui-content-area mfui-content-area_background-color_transparent"
       >
         <div
-          className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+          className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
         >
           <div
             className="mfui-video-banner__wrapper"
@@ -988,15 +928,12 @@ exports[`<VideoBanner /> tests with local window render mobile image on relevant
   <div
     className="mfui-video-banner"
   >
-    <ContentArea
-      innerBackgroundColor="transparent"
-      outerBackgroundColor="transparent"
-    >
+    <ContentArea>
       <div
-        className="mfui-content-area mfui-content-area_color_transparent"
+        className="mfui-content-area mfui-content-area_background-color_transparent"
       >
         <div
-          className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+          className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
         >
           <div
             className="mfui-video-banner__wrapper"
@@ -1027,15 +964,12 @@ exports[`<VideoBanner /> tests with local window render tablet image on relevant
   <div
     className="mfui-video-banner"
   >
-    <ContentArea
-      innerBackgroundColor="transparent"
-      outerBackgroundColor="transparent"
-    >
+    <ContentArea>
       <div
-        className="mfui-content-area mfui-content-area_color_transparent"
+        className="mfui-content-area mfui-content-area_background-color_transparent"
       >
         <div
-          className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+          className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
         >
           <div
             className="mfui-video-banner__wrapper"
@@ -1067,15 +1001,12 @@ exports[`<VideoBanner /> tests with local window render video with sounds enable
   <div
     className="mfui-video-banner"
   >
-    <ContentArea
-      innerBackgroundColor="transparent"
-      outerBackgroundColor="transparent"
-    >
+    <ContentArea>
       <div
-        className="mfui-content-area mfui-content-area_color_transparent"
+        className="mfui-content-area mfui-content-area_background-color_transparent"
       >
         <div
-          className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+          className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
         >
           <div
             className="mfui-video-banner__wrapper"
@@ -1109,15 +1040,12 @@ exports[`<VideoBanner /> tests with local window render wide desktop image on re
   <div
     className="mfui-video-banner"
   >
-    <ContentArea
-      innerBackgroundColor="transparent"
-      outerBackgroundColor="transparent"
-    >
+    <ContentArea>
       <div
-        className="mfui-content-area mfui-content-area_color_transparent"
+        className="mfui-content-area mfui-content-area_background-color_transparent"
       >
         <div
-          className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+          className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
         >
           <div
             className="mfui-video-banner__wrapper"
@@ -1148,15 +1076,12 @@ exports[`<VideoBanner /> tests with local window render with video 1`] = `
   <div
     className="mfui-video-banner"
   >
-    <ContentArea
-      innerBackgroundColor="transparent"
-      outerBackgroundColor="transparent"
-    >
+    <ContentArea>
       <div
-        className="mfui-content-area mfui-content-area_color_transparent"
+        className="mfui-content-area mfui-content-area_background-color_transparent"
       >
         <div
-          className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+          className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
         >
           <div
             className="mfui-video-banner__wrapper"
@@ -1201,15 +1126,12 @@ exports[`<VideoBanner /> tests with local window render with video and content 1
   <div
     className="mfui-video-banner"
   >
-    <ContentArea
-      innerBackgroundColor="transparent"
-      outerBackgroundColor="transparent"
-    >
+    <ContentArea>
       <div
-        className="mfui-content-area mfui-content-area_color_transparent"
+        className="mfui-content-area mfui-content-area_background-color_transparent"
       >
         <div
-          className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+          className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
         >
           <div
             className="mfui-video-banner__wrapper"
@@ -1316,10 +1238,7 @@ exports[`<VideoBanner /> tests with local window render with video and content 1
                           </Button>
                           <TextLink
                             className="mfui-video-banner__link"
-                            color="blue"
                             href="#"
-                            underlineStyle="solid"
-                            underlineVisibility="hover"
                           >
                             <Link
                               className="mfui-text-link mfui-text-link_underline-visibility_hover mfui-text-link_underline-style_solid mfui-text-link_color_blue mfui-video-banner__link"
@@ -1369,15 +1288,12 @@ exports[`<VideoBanner /> tests with local window render with youtube video 1`] =
   <div
     className="mfui-video-banner"
   >
-    <ContentArea
-      innerBackgroundColor="transparent"
-      outerBackgroundColor="transparent"
-    >
+    <ContentArea>
       <div
-        className="mfui-content-area mfui-content-area_color_transparent"
+        className="mfui-content-area mfui-content-area_background-color_transparent"
       >
         <div
-          className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+          className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
         >
           <div
             className="mfui-video-banner__wrapper"
@@ -1410,15 +1326,12 @@ exports[`<VideoBanner /> tests with local window render youtube video with sound
   <div
     className="mfui-video-banner"
   >
-    <ContentArea
-      innerBackgroundColor="transparent"
-      outerBackgroundColor="transparent"
-    >
+    <ContentArea>
       <div
-        className="mfui-content-area mfui-content-area_color_transparent"
+        className="mfui-content-area mfui-content-area_background-color_transparent"
       >
         <div
-          className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+          className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
         >
           <div
             className="mfui-video-banner__wrapper"
@@ -1450,15 +1363,12 @@ exports[`<VideoBanner /> tests with local window should not render background im
   <div
     className="mfui-video-banner"
   >
-    <ContentArea
-      innerBackgroundColor="transparent"
-      outerBackgroundColor="transparent"
-    >
+    <ContentArea>
       <div
-        className="mfui-content-area mfui-content-area_color_transparent"
+        className="mfui-content-area mfui-content-area_background-color_transparent"
       >
         <div
-          className="mfui-content-area__inner mfui-content-area__inner_color_transparent"
+          className="mfui-content-area__inner mfui-content-area__inner_background-color_transparent"
         >
           <div
             className="mfui-video-banner__wrapper"
@@ -1484,10 +1394,7 @@ exports[`<VideoBanner /> tests with local window should not render video on mobi
 <div
   className="mfui-video-banner"
 >
-  <ContentArea
-    innerBackgroundColor="transparent"
-    outerBackgroundColor="transparent"
-  >
+  <ContentArea>
     <div
       className="mfui-video-banner__wrapper"
     >

--- a/packages/ui-shared/src/components/VideoBlock/VideoBlock.test.tsx
+++ b/packages/ui-shared/src/components/VideoBlock/VideoBlock.test.tsx
@@ -51,8 +51,17 @@ describe('<VideoBlock />', () => {
     });
 
     it('it renders VideoBlock with dataAttrs', () => {
-        const component = shallow(<VideoBlock videoSrc="video.mp4" dataAttrs={{ 'data-test': 'value' }} />);
-        expect(component.first().prop('data-test')).toEqual('value');
+        const component = shallow(
+            <VideoBlock
+                videoSrc="video.mp4"
+                content={content}
+                dataAttrs={{
+                    root: { 'data-testid': 'root-test' },
+                    button: { 'data-testid': 'button-test' },
+                }}
+            />,
+        );
+        expect(component).toMatchSnapshot();
     });
 
     it('it renders VideoBlock with sound turned on', () => {

--- a/packages/ui-shared/src/components/VideoBlock/VideoBlock.tsx
+++ b/packages/ui-shared/src/components/VideoBlock/VideoBlock.tsx
@@ -27,8 +27,11 @@ export const VideoTypes = {
 type VideoType = typeof VideoTypes[keyof typeof VideoTypes];
 
 export interface IVideoBlockProps {
-    /** Дата атрибуты для корневого элемента */
-    dataAttrs?: { [key: string]: string };
+    /** Дополнительные data атрибуты к внутренним элементам */
+    dataAttrs?: {
+        root?: Record<string, string>;
+        button?: Record<string, string>;
+    };
     /** Дополнительный класс корневого элемента */
     className?: string;
     /** Дополнительные классы для корневого и внутренних элементов */
@@ -97,6 +100,7 @@ const VideoBlock: React.FC<IVideoBlockProps> = ({
                 <div className={cn('description', [classes.description])}>{description}</div>
                 {buttonTitle && (
                     <Button
+                        dataAttrs={{ root: dataAttrs?.button }}
                         className={cn('button', [classes.button])}
                         href={href}
                         onClick={onButtonClick}
@@ -107,7 +111,7 @@ const VideoBlock: React.FC<IVideoBlockProps> = ({
                 )}
             </div>
         ),
-        [classes.button, classes.description],
+        [classes.button, classes.description, dataAttrs?.button],
     );
 
     const renderGridColumns = React.useCallback(() => {
@@ -132,7 +136,7 @@ const VideoBlock: React.FC<IVideoBlockProps> = ({
     }, [renderContent, renderVideo, content]);
 
     return (
-        <div {...filterDataAttrs(dataAttrs)} className={cn([className, classes.root])} ref={rootRef}>
+        <div {...filterDataAttrs(dataAttrs?.root)} className={cn([className, classes.root])} ref={rootRef}>
             <Grid hAlign="center" className={cn('grid')}>
                 {renderGridColumns()}
             </Grid>
@@ -141,7 +145,10 @@ const VideoBlock: React.FC<IVideoBlockProps> = ({
 };
 
 VideoBlock.propTypes = {
-    dataAttrs: PropTypes.objectOf(PropTypes.string.isRequired),
+    dataAttrs: PropTypes.shape({
+        root: PropTypes.objectOf(PropTypes.string.isRequired),
+        button: PropTypes.objectOf(PropTypes.string.isRequired),
+    }),
     className: PropTypes.string,
     classes: PropTypes.shape({
         root: PropTypes.string,

--- a/packages/ui-shared/src/components/VideoBlock/__snapshots__/VideoBlock.test.tsx.snap
+++ b/packages/ui-shared/src/components/VideoBlock/__snapshots__/VideoBlock.test.tsx.snap
@@ -67,6 +67,11 @@ exports[`<VideoBlock /> it renders VideoBlock with classes 1`] = `
         </div>
         <Button
           className="mfui-video-block__button buttonClass"
+          dataAttrs={
+            Object {
+              "root": undefined,
+            }
+          }
           href="#"
         >
           Button title
@@ -132,6 +137,11 @@ exports[`<VideoBlock /> it renders VideoBlock with content 1`] = `
         </div>
         <Button
           className="mfui-video-block__button"
+          dataAttrs={
+            Object {
+              "root": undefined,
+            }
+          }
           href="#"
         >
           Button title
@@ -197,6 +207,11 @@ exports[`<VideoBlock /> it renders VideoBlock with content and button download l
         </div>
         <Button
           className="mfui-video-block__button"
+          dataAttrs={
+            Object {
+              "root": undefined,
+            }
+          }
           download={true}
           href="#"
         >
@@ -261,6 +276,79 @@ exports[`<VideoBlock /> it renders VideoBlock with content but without button 1`
         >
           Test description
         </div>
+      </div>
+    </GridColumn>
+    <GridColumn
+      all="7"
+      key="column-video"
+      mobile="12"
+      tablet="12"
+    >
+      <div
+        className="mfui-video-block__video-wrapper mfui-video-block__video-wrapper_with-content"
+      >
+        <video
+          autoPlay={false}
+          className="mfui-video-block__video"
+          controls={true}
+          loop={true}
+          muted={true}
+        >
+          <source
+            src="video.mp4"
+            type="video/mp4"
+          />
+        </video>
+      </div>
+    </GridColumn>
+  </Grid>
+</div>
+`;
+
+exports[`<VideoBlock /> it renders VideoBlock with dataAttrs 1`] = `
+<div
+  className="mfui-video-block"
+  data-testid="root-test"
+>
+  <Grid
+    className="mfui-video-block__grid"
+    hAlign="center"
+  >
+    <GridColumn
+      all="5"
+      key="column-content"
+      mobile="12"
+      orderMobile="2"
+      orderTablet="2"
+      tablet="12"
+    >
+      <div
+        className="mfui-video-block__content"
+      >
+        <Header
+          as="h2"
+          className="mfui-video-block__header"
+        >
+          Test title
+        </Header>
+        <div
+          className="mfui-video-block__description"
+        >
+          Test description
+        </div>
+        <Button
+          className="mfui-video-block__button"
+          dataAttrs={
+            Object {
+              "root": Object {
+                "data-testid": "button-test",
+              },
+            }
+          }
+          href="#"
+        >
+          Button title
+        </Button>
       </div>
     </GridColumn>
     <GridColumn

--- a/yarn.lock
+++ b/yarn.lock
@@ -4567,17 +4567,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.5.5:
-  version "6.12.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
-  integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^6.12.4:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.12.4, ajv@^6.5.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -9856,12 +9846,7 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-deep-equal@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
-  integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
-
-fast-deep-equal@^3.1.3:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -22209,9 +22194,9 @@ upper-case@^1.0.3, upper-case@^1.1.0, upper-case@^1.1.1, upper-case@^1.1.3:
   integrity sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=
 
 uri-js@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
-  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22244,9 +22244,9 @@ url-parse-lax@^3.0.0:
     prepend-http "^2.0.0"
 
 url-parse@^1.1.8, url-parse@^1.4.3:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.3.tgz#71c1303d38fb6639ade183c2992c8cc0686df862"
-  integrity sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==
+  version "1.5.7"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.7.tgz#00780f60dbdae90181f51ed85fb24109422c932a"
+  integrity sha512-HxWkieX+STA38EDk7CE9MEryFeHCKzgagxlGvsdS7WBImq9Mk+PGwiT56w82WI3aicwJA8REp42Cxo98c8FZMA==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"


### PR DESCRIPTION
<!-- Autogenerated checksum:32bce9f62ae916e26f8e022e98c0415a71b3318e_4b17f93542394e8d78a3ae697fc4b3f5b1662485 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "3.0.2"
"version": "3.1.0"

ui-shared/package.json
"version": "3.0.3"
"version": "3.1.0"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
# [3.1.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@3.0.2...@megafon/ui-core@3.1.0) (2022-02-22)


### Bug Fixes

* **carousel:** add resize listener to nav display ([12abd93](https://github.com/MegafonWebLab/megafon-ui/commit/12abd93d226676d2c4f78968c9d5de032783ec8d))
* **colors:** fix colors usage ([f2f59a8](https://github.com/MegafonWebLab/megafon-ui/commit/f2f59a81644c157394817af1531dabb1c0b67b19))
* **components:** better view of default props values ([1817ed5](https://github.com/MegafonWebLab/megafon-ui/commit/1817ed5cd17fd78a0911a89020138f05d7af9833))
* **contentarea:** add 'black' color prop value; deprecate 'default' color prop value; more examples ([e0b0c72](https://github.com/MegafonWebLab/megafon-ui/commit/e0b0c723a37f0e42ccb1c0d30df8ae36e9c82920))


### Features

* **banner:** add opacity for slides ([bb403a1](https://github.com/MegafonWebLab/megafon-ui/commit/bb403a1d38fd0c1efd3e1df3ed72ea4e5c772c40))
* **collapse:** changed collapse animation via setTimeout to requestAnimationFrame ([06d7b4f](https://github.com/MegafonWebLab/megafon-ui/commit/06d7b4ff0f3cdf3cc22fb1d45e8401e259636cf5))
* **ui-core:** add dataAttrs prop for interactive elements of components that did not have ([f495833](https://github.com/MegafonWebLab/megafon-ui/commit/f495833b33ac7823ae5992a3f7eb8b7cef82c036))





## :memo: packages/ui-shared/CHANGELOG.md
# [3.1.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.0.3...@megafon/ui-shared@3.1.0) (2022-02-22)


### Bug Fixes

* **videobanner:** update snapshots ([77de901](https://github.com/MegafonWebLab/megafon-ui/commit/77de901fa76793cf76dc776b3234b2d792befd9a))
* fix Breadcrumbs, ButtonLinkBox, Card, CardBox, Container, DownloadLink & VideoBanner snapshots ([e149e2d](https://github.com/MegafonWebLab/megafon-ui/commit/e149e2d40ececff0065ec1d800fb807fabfe8640))
* **breadcrumbs:** allow to pass items as array of JSX elements ([1ca1583](https://github.com/MegafonWebLab/megafon-ui/commit/1ca158390c7c58b5ff117ae8ad16268b043d5ddb))
* **colors:** fix colors usage ([f2f59a8](https://github.com/MegafonWebLab/megafon-ui/commit/f2f59a81644c157394817af1531dabb1c0b67b19))
* **components:** better view of default props values ([1817ed5](https://github.com/MegafonWebLab/megafon-ui/commit/1817ed5cd17fd78a0911a89020138f05d7af9833))


### Features

* **textwithiconitem:** add type string[] for text prop ([0df9680](https://github.com/MegafonWebLab/megafon-ui/commit/0df9680e10058ea24783fbc41cbce17e9b2a5594))
* **ui-shared:** add dataAttrs prop for interactive elements of components that did not have ([6b2fad8](https://github.com/MegafonWebLab/megafon-ui/commit/6b2fad84e72269d1fac0408e0b7e94202866b4aa))
* **videobanner:** added new classes for video ([d8b84a0](https://github.com/MegafonWebLab/megafon-ui/commit/d8b84a003103cf5f66102d354d2625e30a2c0d2a))





