### PR TITLE
feat(tile): add target props for link

### DIFF
--- a/packages/ui-core/src/components/Tile/Tile.test.tsx
+++ b/packages/ui-core/src/components/Tile/Tile.test.tsx
@@ -10,6 +10,7 @@ const props: ITileProps = {
     shadowLevel: Shadow.HIGH,
     isInteractive: true,
     onClick: jest.fn(),
+    target: '_blank',
 };
 
 describe('<Tile />', () => {

--- a/packages/ui-core/src/components/Tile/Tile.tsx
+++ b/packages/ui-core/src/components/Tile/Tile.tsx
@@ -29,6 +29,8 @@ type ShadowType = typeof Shadow[keyof typeof Shadow];
 export interface ITileProps {
     /** Ссылка */
     href?: string;
+    /** Атрибут для открытия ссылки */
+    target?: '_self' | '_blank';
     /** Тема */
     theme?: ThemeType;
     /** Радиус границы */
@@ -58,6 +60,7 @@ const Tile: React.FC<ITileProps> = ({
     isInteractive = false,
     onClick,
     dataAttrs,
+    target = '_self',
 }) => {
     const handleClick = (e: React.MouseEvent<HTMLDivElement>): void => {
         onClick?.(e);
@@ -80,7 +83,7 @@ const Tile: React.FC<ITileProps> = ({
             {...filterDataAttrs(dataAttrs?.root)}
         >
             {href && (
-                <a href={href} className={cn('link')}>
+                <a href={href} className={cn('link')} target={target}>
                     {children}
                 </a>
             )}
@@ -100,6 +103,7 @@ Tile.propTypes = {
     dataAttrs: PropTypes.shape({
         root: PropTypes.objectOf(PropTypes.string.isRequired),
     }),
+    target: PropTypes.oneOf(['_self', '_blank',]),
 };
 
 export default Tile;

--- a/packages/ui-core/src/components/Tile/Tile.tsx
+++ b/packages/ui-core/src/components/Tile/Tile.tsx
@@ -103,7 +103,7 @@ Tile.propTypes = {
     dataAttrs: PropTypes.shape({
         root: PropTypes.objectOf(PropTypes.string.isRequired),
     }),
-    target: PropTypes.oneOf(['_self', '_blank',]),
+    target: PropTypes.oneOf(['_self', '_blank']),
 };
 
 export default Tile;

--- a/packages/ui-core/src/components/Tile/__snapshots__/Tile.test.tsx.snap
+++ b/packages/ui-core/src/components/Tile/__snapshots__/Tile.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`<Tile /> snapshots renders component with props 1`] = `
   <a
     className="mfui-tile__link"
     href="test-link"
+    target="_blank"
   >
     Some test content
   </a>

--- a/packages/ui-core/src/components/Tile/doc/Tile.example.mdx
+++ b/packages/ui-core/src/components/Tile/doc/Tile.example.mdx
@@ -112,7 +112,7 @@ const tileInner = {
         <Tile shadowLevel="high" href="#">
             <div style={tileInner}>High shadow</div>
         </Tile>
-        <Tile shadowLevel="hover" href="#">
+        <Tile shadowLevel="hover" href="#" target="_blank">
             <div style={tileInner}>Hover shadow</div>
         </Tile>
     </DemoTileWrapper>


### PR DESCRIPTION
<!-- Autogenerated checksum:3b91f6030703838090828a8a77cff3d82cb14c10_1f0ed9009ef2cb9e5562f257640a623eceae225e -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "3.1.0"
"version": "3.2.0"

ui-shared/package.json
"version": "3.1.0"
"version": "3.1.1"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
# [3.2.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@3.1.0...@megafon/ui-core@3.2.0) (2022-02-28)


### Bug Fixes

* **tile:** delete unnecessary symbol ([1f0ed90](https://github.com/MegafonWebLab/megafon-ui/commit/1f0ed9009ef2cb9e5562f257640a623eceae225e))


### Features

* **tile:** add target props for link ([e49d040](https://github.com/MegafonWebLab/megafon-ui/commit/e49d0402725e88b9fd7d80fd418acd81bea321ba))





## :memo: packages/ui-shared/CHANGELOG.md
## [3.1.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.1.0...@megafon/ui-shared@3.1.1) (2022-02-28)

**Note:** Version bump only for package @megafon/ui-shared





