### PR TITLE
fix(accordion): remove outline for safari

### DIFF
--- a/packages/ui-core/src/components/Accordion/Accordion.less
+++ b/packages/ui-core/src/components/Accordion/Accordion.less
@@ -41,6 +41,8 @@
         width: 32px;
         height: 32px;
 
+        outline: none;
+
         transform: translateY(-50%);
         opacity: 1;
 


### PR DESCRIPTION
<!-- Autogenerated checksum:da8e73a70fd2d46d3d7fa09c6b9ef81aa51d04ca_787b5725ef962637401a0a3a1a8ae7ba0cece031 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "3.2.0"
"version": "3.2.1"

ui-shared/package.json
"version": "3.1.1"
"version": "3.1.2"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
## [3.2.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@3.2.0...@megafon/ui-core@3.2.1) (2022-03-14)


### Bug Fixes

* **accordion:** remove outline for safari ([787b572](https://github.com/MegafonWebLab/megafon-ui/commit/787b5725ef962637401a0a3a1a8ae7ba0cece031))





## :memo: packages/ui-shared/CHANGELOG.md
## [3.1.2](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.1.1...@megafon/ui-shared@3.1.2) (2022-03-14)

**Note:** Version bump only for package @megafon/ui-shared





