### PR TITLE
refactor(collapse): made collapse height auto on animation end if col…

### DIFF
--- a/packages/ui-core/src/components/Collapse/Collapse.tsx
+++ b/packages/ui-core/src/components/Collapse/Collapse.tsx
@@ -73,9 +73,10 @@ const Collapse = (props: CollapseProps): React.FunctionComponentElement<Collapse
             } else {
                 animationStart.current = null;
                 animationId.current = null;
+                rootNode.current.style.height = isOpenAction ? 'auto' : '0px';
             }
         },
-        [],
+        [isOpened],
     );
 
     useEffect(() => {

--- a/packages/ui-core/src/components/Collapse/Collapse.tsx
+++ b/packages/ui-core/src/components/Collapse/Collapse.tsx
@@ -76,7 +76,7 @@ const Collapse = (props: CollapseProps): React.FunctionComponentElement<Collapse
                 rootNode.current.style.height = isOpenAction ? 'auto' : '0px';
             }
         },
-        [isOpened],
+        [],
     );
 
     useEffect(() => {

--- a/src/gatsby-theme-docz/components/Layout/Layout.less
+++ b/src/gatsby-theme-docz/components/Layout/Layout.less
@@ -79,12 +79,12 @@
 
         @media screen and (min-width: 768px) {
             padding-left: 240px;
-            max-width: 1680px;
         }
     }
 
     &__content-inner {
         padding: 80px;
+        max-width: 1600px;
 
         color: var(--content);
 


### PR DESCRIPTION
…lapse opened<!-- Autogenerated checksum:b6bf84964965b357194c4868ab9bc9ae45a1e2ce_0e0f04bac13d06ea4b726de4182c83afde0c55d2 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "3.3.0"
"version": "3.3.1"

ui-shared/package.json
"version": "3.1.2"
"version": "3.1.3"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
## [3.3.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@3.3.0...@megafon/ui-core@3.3.1) (2022-03-15)


### Bug Fixes

* **collapse:** made collapse height 0 or auto on animation end ([c898d1e](https://github.com/MegafonWebLab/megafon-ui/commit/c898d1e84d3c92defa204c24125508655466d5cd))





## :memo: packages/ui-shared/CHANGELOG.md
## [3.1.3](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.1.2...@megafon/ui-shared@3.1.3) (2022-03-15)

**Note:** Version bump only for package @megafon/ui-shared





