### PR TITLE
docs(icons): added fixed width of 32px to fix firefox display

### DIFF
--- a/packages/ui-icons/src/doc/Icons.less
+++ b/packages/ui-icons/src/doc/Icons.less
@@ -66,6 +66,7 @@
     &__icon {
         position: relative;
         z-index: 5;
+        width: 32px;
         min-width: 32px;
         margin-right: 8px;
         transition: all 0.2s ease;


### PR DESCRIPTION
<!-- Autogenerated checksum:4ef906c6961b5da2721dcde19062766c4fe8ba84_cae427c6e31970ec3458f9b33ceeed919ee31461 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "3.3.1"
"version": "3.3.2"

ui-icons/package.json
"version": "1.1.0"
"version": "1.1.1"

ui-shared/package.json
"version": "3.1.3"
"version": "3.1.4"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
## [3.3.2](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@3.3.1...@megafon/ui-core@3.3.2) (2022-03-17)

**Note:** Version bump only for package @megafon/ui-core





## :memo: packages/ui-icons/CHANGELOG.md
## [1.1.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-icons@1.1.0...@megafon/ui-icons@1.1.1) (2022-03-17)

**Note:** Version bump only for package @megafon/ui-icons





## :memo: packages/ui-shared/CHANGELOG.md
## [3.1.4](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.1.3...@megafon/ui-shared@3.1.4) (2022-03-17)

**Note:** Version bump only for package @megafon/ui-shared





