### PR TITLE
fix(breadcrumbs): change default color prop value from black to default

### DIFF
--- a/packages/ui-shared/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/ui-shared/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -41,7 +41,7 @@ function isJSXElement(item: ItemType): item is JSX.Element {
 }
 
 const cn = cnCreate('mfui-breadcrumbs');
-const Breadcrumbs: React.FC<Props> = ({ items, color = 'black', className, classes = {}, dataAttrs }) => (
+const Breadcrumbs: React.FC<Props> = ({ items, color = 'default', className, classes = {}, dataAttrs }) => (
     <div {...filterDataAttrs(dataAttrs?.root)} className={cn({ color }, className)}>
         {items.map((item: ItemType, i: number): JSX.Element | null => {
             if (isJSXElement(item)) {

--- a/packages/ui-shared/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/packages/ui-shared/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`Breadcrumbs should render component 1`] = `
 <div
-  className="mfui-breadcrumbs mfui-breadcrumbs_color_black"
+  className="mfui-breadcrumbs mfui-breadcrumbs_color_default"
 >
   <div
     className="mfui-breadcrumbs__item"
     key="МегаФон"
   >
     <TextLink
-      color="black"
+      color="default"
       dataAttrs={
         Object {
           "root": undefined,
@@ -25,7 +25,7 @@ exports[`Breadcrumbs should render component 1`] = `
     key="Мобильная связь"
   >
     <TextLink
-      color="black"
+      color="default"
       dataAttrs={
         Object {
           "root": undefined,
@@ -41,7 +41,7 @@ exports[`Breadcrumbs should render component 1`] = `
     key="Тарифы"
   >
     <TextLink
-      color="black"
+      color="default"
       dataAttrs={
         Object {
           "root": undefined,


### PR DESCRIPTION
new default value for prop 'color' is 'default' instead of 'black'

BREAKING CHANGE: color is now depends on current theme. by default it matches content text color.
for keep black color on light background use 'black' value for prop 'color'.<!-- Autogenerated checksum:6827903210a6e8d68c67db13b16df4a61684e7ef_9c2c0fca7d559a67d3d167b2a8a3c30b420ab7da -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-shared/package.json
"version": "3.1.4"
"version": "4.0.0"
```
### Changelogs:
## :memo: packages/ui-shared/CHANGELOG.md
# [4.0.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.1.4...@megafon/ui-shared@4.0.0) (2022-03-30)


### Bug Fixes

* **breadcrumbs:** change default color prop value from black to default ([9c2c0fc](https://github.com/MegafonWebLab/megafon-ui/commit/9c2c0fca7d559a67d3d167b2a8a3c30b420ab7da))


### BREAKING CHANGES

* **breadcrumbs:** color is now depends on current theme. by default it matches content text color.
for keep black color on light background use 'black' value for prop 'color'.





