### PR TITLE
fix(select): smooth scroll highlighted item into users view

### DIFF
--- a/packages/ui-core/src/components/Select/Select.tsx
+++ b/packages/ui-core/src/components/Select/Select.tsx
@@ -164,29 +164,10 @@ const Select = <T extends SelectItemValueType>({
     );
 
     const scrollList = (itemIndex: number): void => {
-        if (!itemsNodeList.current.length) {
-            return;
-        }
-
-        const wrapper = itemWrapperNode.current;
-        const item = itemsNodeList.current[itemIndex];
-
-        if (!item || !wrapper) {
-            return;
-        }
-
-        const wrapperScroll = wrapper?.scrollTop;
-        const wrapperHeight = wrapper?.offsetHeight;
-        const itemOffset = item.offsetTop;
-        const itemHeight = item.offsetHeight;
-
-        if (itemOffset + itemHeight > wrapperScroll + wrapperHeight) {
-            wrapper.scrollTop = itemOffset + itemHeight - wrapperHeight;
-        }
-
-        if (itemOffset < wrapperScroll) {
-            wrapper.scrollTop = itemOffset;
-        }
+        itemsNodeList.current[itemIndex]?.scrollIntoView?.({
+            behavior: 'smooth',
+            block: 'nearest',
+        });
     };
 
     useEffect(() => {


### PR DESCRIPTION
- `Select`: smooth scroll highlighted item into users view<!-- Autogenerated checksum:48ac683c2daf04dfdc42d1359024800699f2e7dc_50860e82a557cd6dd2e89448740a13b6e25c8261 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "3.5.0"
"version": "3.5.1"

ui-shared/package.json
"version": "3.2.0"
"version": "3.2.1"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
## [3.5.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@3.5.0...@megafon/ui-core@3.5.1) (2022-04-07)


### Bug Fixes

* **select:** scroll highlighted item into users view ([50860e8](https://github.com/MegafonWebLab/megafon-ui/commit/50860e82a557cd6dd2e89448740a13b6e25c8261))





## :memo: packages/ui-shared/CHANGELOG.md
## [3.2.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.2.0...@megafon/ui-shared@3.2.1) (2022-04-07)

**Note:** Version bump only for package @megafon/ui-shared





