### PR TITLE
fix(ui-icons): fixed service icon names

### DIFF
--- a/packages/ui-icons/src/Service-logos/24/Yandex-disk.svg
+++ b/packages/ui-icons/src/Service-logos/24/Yandex-disk.svg
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 50 (54983) - http://www.bohemiancoding.com/sketch -->
-    <title>logo/24/yandex-disc</title>
-    <desc>Created with Sketch.</desc>
     <defs>
         <linearGradient x1="35.276%" y1="12.669%" x2="50%" y2="68.332%" id="linearGradient-1">
             <stop stop-color="#FFFFFF" offset="0%"></stop>
             <stop stop-color="#FFFFFF" stop-opacity="0" offset="100%"></stop>
         </linearGradient>
     </defs>
-    <g id="logo/24/yandex-disc" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="logo/24/yandex-disk" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="XpKALBy718TbzrhYiZ9T1iAmYn4" transform="translate(8.000000, 10.500000)">
             <path d="M11.1217778,0.834545455 C10.4650667,0.823636364 10.0224,0.629454545 9.48977778,0.457818182 C8.32106667,0.0796363636 6.87431111,0.101454545 5.54915556,0.736 C4.40355556,1.28436364 3.55271111,2.19418182 3.05315556,3.17490909 C2.69653333,3.87527273 2.3936,4.68763636 1.94666667,5.18509091 L1.88088889,5.25527273 L1.87911111,5.25709091 L1.87128889,5.26509091 C0.404977778,6.83818182 -0.253155556,8.45418182 0.232177778,9.48509091 C1.30062222,11.7552727 16.6993778,4.37818182 15.6312889,2.10909091 C15.2131556,1.22109091 13.4161778,0.677090909 11.1228444,0.834545455 L11.1217778,0.834545455 Z" id="Shape" fill="#000000" fill-rule="nonzero"></path>
             <path d="M9.67964444,9.41381818 C13.9491556,7.36836364 16.4977778,3.77090909 15.8044444,2.29963636 C15.1121778,0.828363636 10.9504,1.09163636 6.68088889,3.13745455 C2.41066667,5.18290909 -0.349511111,8.23563636 0.342755556,9.70654545 C1.03537778,11.1778182 5.40942222,11.4592727 9.67964444,9.41381818 Z" id="Shape" fill="#0077FF" fill-rule="nonzero"></path>

--- a/packages/ui-icons/src/Service-logos/24/Yandex-navigator.svg
+++ b/packages/ui-icons/src/Service-logos/24/Yandex-navigator.svg
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 50 (54983) - http://www.bohemiancoding.com/sketch -->
-    <title>logo/24/yandex-naviator</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="logo/24/yandex-naviator" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="logo/24/yandex-navigator" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="Group-2" transform="translate(8.000000, 10.000000)">
             <polygon id="Path-2" fill="#FFE065" points="0.000136174054 5.55963151 13.9830236 0.00555078125 8.43189741 14 5.71660493 8.29421615"></polygon>
             <polygon id="Path-2" fill="#ECA704" points="0.000136174054 5.55963151 7.30677291 6.70133333 8.43189741 14 5.71660493 8.29421615"></polygon>


### PR DESCRIPTION
BREAKING CHANGE: renamed import paths for yandex-disc and yandex-naviator icons (fixed icon names)<!-- Autogenerated checksum:48ac683c2daf04dfdc42d1359024800699f2e7dc_02035e8c053d9780d11313ffd56ca9a5d0e9bfd0 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "3.5.0"
"version": "3.5.1"

ui-icons/package.json
"version": "1.1.1"
"version": "2.0.0"

ui-shared/package.json
"version": "3.2.0"
"version": "3.2.1"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
## [3.5.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@3.5.0...@megafon/ui-core@3.5.1) (2022-04-11)

**Note:** Version bump only for package @megafon/ui-core





## :memo: packages/ui-icons/CHANGELOG.md
# [2.0.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-icons@1.1.1...@megafon/ui-icons@2.0.0) (2022-04-11)


### Bug Fixes

* **ui-icons:** fixed service icon names ([02035e8](https://github.com/MegafonWebLab/megafon-ui/commit/02035e8c053d9780d11313ffd56ca9a5d0e9bfd0))


### BREAKING CHANGES

* **ui-icons:** renamed import paths for yandex-disc and yandex-naviator icons (fixed icon names)





## :memo: packages/ui-shared/CHANGELOG.md
## [3.2.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.2.0...@megafon/ui-shared@3.2.1) (2022-04-11)

**Note:** Version bump only for package @megafon/ui-shared





