### PR TITLE
feat(notification): add props classes to notification component

### DIFF
--- a/packages/ui-core/src/components/Notification/Notification.test.tsx
+++ b/packages/ui-core/src/components/Notification/Notification.test.tsx
@@ -5,6 +5,11 @@ import Notification, { INotificationProps, NotificationTypes, ShadowTypes } from
 
 const props: INotificationProps = {
     className: 'notification',
+    classes: {
+        root: 'rootClass',
+        container: 'containerClass',
+        content: 'contentClass',
+    },
     type: NotificationTypes.ERROR,
     shadowLevel: ShadowTypes.HOVER,
     href: 'href',

--- a/packages/ui-core/src/components/Notification/Notification.tsx
+++ b/packages/ui-core/src/components/Notification/Notification.tsx
@@ -33,6 +33,12 @@ type ShadowType = typeof ShadowTypes[keyof typeof ShadowTypes];
 export interface INotificationProps {
     /** Дополнительный класс корневого элемента */
     className?: string;
+    /** Дополнительные классы для корневого и внутренних элементов */
+    classes?: {
+        root?: string;
+        container?: string;
+        content?: string;
+    };
     /** Тип отображения */
     type?: NotificationType;
     /** Уровень тени */
@@ -70,6 +76,7 @@ export interface INotificationProps {
 const cn = cnCreate('mfui-notification');
 const Notification: React.FC<INotificationProps> = ({
     className,
+    classes: { root: rootClass, container: containerClass, content: contentClass } = {},
     children,
     type = 'info',
     shadowLevel = 'zero',
@@ -128,13 +135,13 @@ const Notification: React.FC<INotificationProps> = ({
                     type,
                     colored: isColored,
                 },
-                className,
+                [className, rootClass],
             )}
         >
-            <div className={cn('container')}>
+            <div className={cn('container', [containerClass])}>
                 <div className={cn('icon-container')}>{renderIcon()}</div>
 
-                <div className={cn('content')}>
+                <div className={cn('content', [contentClass])}>
                     {title && (
                         <Header
                             dataAttrs={{ root: dataAttrs?.title }}
@@ -165,6 +172,11 @@ const Notification: React.FC<INotificationProps> = ({
 Notification.propTypes = {
     type: PropTypes.oneOf(Object.values(NotificationTypes)),
     className: PropTypes.string,
+    classes: PropTypes.shape({
+        root: PropTypes.string,
+        container: PropTypes.string,
+        content: PropTypes.string,
+    }),
     shadowLevel: PropTypes.oneOf(Object.values(ShadowTypes)),
     isColored: PropTypes.bool,
     hasCloseButton: PropTypes.bool,

--- a/packages/ui-core/src/components/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/packages/ui-core/src/components/Notification/__snapshots__/Notification.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Notification /> it renders colored Notification with Props 1`] = `
 <Tile
-  className="mfui-notification mfui-notification_type_error mfui-notification_colored notification"
+  className="mfui-notification mfui-notification_type_error mfui-notification_colored notification rootClass"
   dataAttrs={
     Object {
       "root": undefined,
@@ -12,7 +12,7 @@ exports[`<Notification /> it renders colored Notification with Props 1`] = `
   shadowLevel="hover"
 >
   <div
-    className="mfui-notification__container"
+    className="mfui-notification__container containerClass"
   >
     <div
       className="mfui-notification__icon-container"
@@ -20,7 +20,7 @@ exports[`<Notification /> it renders colored Notification with Props 1`] = `
       <test-file-stub />
     </div>
     <div
-      className="mfui-notification__content"
+      className="mfui-notification__content contentClass"
     >
       <Header
         as="h5"


### PR DESCRIPTION
Fix text width and align on mobile resolution in Notification component.<!-- Autogenerated checksum:be6065a442b0c2f8f1a82ea4fd45dd36679cbfaf_608a4246eb99af354fb7cf8ab98c2ed513d87b66 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "3.7.0"
"version": "3.8.0"

ui-shared/package.json
"version": "3.3.2"
"version": "3.3.3"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
# [3.8.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@3.7.0...@megafon/ui-core@3.8.0) (2022-05-17)


### Features

* **notification:** add props classes to notification component ([608a424](https://github.com/MegafonWebLab/megafon-ui/commit/608a4246eb99af354fb7cf8ab98c2ed513d87b66))





## :memo: packages/ui-shared/CHANGELOG.md
## [3.3.3](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.3.2...@megafon/ui-shared@3.3.3) (2022-05-17)

**Note:** Version bump only for package @megafon/ui-shared





