### PR TITLE
fix(picturewithdescription): fix clearing indents for first and last …

### DIFF
--- a/packages/ui-shared/src/components/PictureWithDescription/PictureWithDescription.less
+++ b/packages/ui-shared/src/components/PictureWithDescription/PictureWithDescription.less
@@ -41,11 +41,11 @@
         height: 100%;
     }
 
-    &__content :first-child {
+    &__content > :first-child {
         margin-top: 0 !important;
     }
 
-    &__content :last-child {
+    &__content > :last-child {
         margin-bottom: 0 !important;
     }
 


### PR DESCRIPTION
…element

indents cleanup for child components will no longer propagate to nested elements<!-- Autogenerated checksum:929d0fbafbdc4d2aa98f283f7c71dff21347542f_d9263e3670b2d493ec4bf194a2cdd6440d1ea86f -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-shared/package.json
"version": "3.3.3"
"version": "3.3.4"
```
### Changelogs:
## :memo: packages/ui-shared/CHANGELOG.md
## [3.3.4](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.3.3...@megafon/ui-shared@3.3.4) (2022-05-20)


### Bug Fixes

* **picturewithdescription:** fix clearing indents for first and last element ([d9263e3](https://github.com/MegafonWebLab/megafon-ui/commit/d9263e3670b2d493ec4bf194a2cdd6440d1ea86f))





