### PR TITLE
fix(select): fix selected item color when value is zero

### DIFF
--- a/packages/ui-core/src/components/Select/Select.tsx
+++ b/packages/ui-core/src/components/Select/Select.tsx
@@ -393,7 +393,7 @@ const Select = <T extends SelectItemValueType>({
                 className={cn(
                     'title',
                     {
-                        placeholder: !!placeholder && !currentValue,
+                        placeholder: !!placeholder && currentValue === undefined,
                     },
                     [classes?.title],
                 )}

--- a/packages/ui-core/src/components/Select/doc/Select.docz.tsx
+++ b/packages/ui-core/src/components/Select/doc/Select.docz.tsx
@@ -3,8 +3,12 @@ import { ISelectItem, SelectItemValueType } from '../Select';
 
 export const items = [
     {
-        value: 1,
+        value: 0,
         title: 'Авиамоторная',
+    },
+    {
+        value: 1,
+        title: 'Автозаводская',
     },
     {
         value: 2,

--- a/packages/ui-core/src/components/Select/doc/Select.example.mdx
+++ b/packages/ui-core/src/components/Select/doc/Select.example.mdx
@@ -31,8 +31,12 @@ const DemoSelectWrapper = props => {
 ```javascript collapse=Демо данные
 const items = [
     {
-        value: 1,
+        value: 0,
         title: 'Авиамоторная',
+    },
+    {
+        value: 1,
+        title: 'Автозаводская',
     },
     {
         value: 2,


### PR DESCRIPTION
<!-- Autogenerated checksum:4afee2ab6a39e2713d8312d4b0fbc8b3a88a0570_98470955ef813504d4bfa4cd4d3aba77b5458446 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "3.8.0"
"version": "3.8.1"

ui-shared/package.json
"version": "3.3.4"
"version": "3.3.5"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
## [3.8.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@3.8.0...@megafon/ui-core@3.8.1) (2022-05-25)


### Bug Fixes

* **select:** fix selected item color when value is zero ([9847095](https://github.com/MegafonWebLab/megafon-ui/commit/98470955ef813504d4bfa4cd4d3aba77b5458446))





## :memo: packages/ui-shared/CHANGELOG.md
## [3.3.5](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.3.4...@megafon/ui-shared@3.3.5) (2022-05-25)

**Note:** Version bump only for package @megafon/ui-shared





