### PR TITLE
feat(notification): add ability to display button and collapse 

### DIFF
--- a/packages/ui-core/src/components/Button/Button.less
+++ b/packages/ui-core/src/components/Button/Button.less
@@ -12,6 +12,8 @@
     border: none;
     border-radius: 30px;
 
+    overflow: hidden;
+
     color: var(--stcWhite);
     font-weight: 500;
     text-align: center;
@@ -62,9 +64,21 @@
         margin-bottom: 2px;
     }
 
+    &__text_ellipsis {
+        overflow: hidden;
+
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+
     &__content {
         display: flex;
         align-items: center;
+    }
+
+    &__content_ellipsis {
+        width: inherit;
+        max-width: fit-content;
     }
 
     &__icon-arrow {
@@ -331,6 +345,10 @@
 }
 
 .generateSize(@resolution) {
+    &_size-@{resolution}_extra-small {
+        padding: 0 16px;
+    }
+
     &_size-@{resolution}_extra-small &__inner {
         min-width: 26px;
         height: 26px;

--- a/packages/ui-core/src/components/Button/Button.less
+++ b/packages/ui-core/src/components/Button/Button.less
@@ -350,6 +350,8 @@
     }
 
     &_size-@{resolution}_extra-small &__inner {
+        .smallFont();
+
         min-width: 26px;
         height: 26px;
     }

--- a/packages/ui-core/src/components/Button/Button.test.tsx
+++ b/packages/ui-core/src/components/Button/Button.test.tsx
@@ -139,6 +139,13 @@ describe('<Button />', () => {
             const wrapper = shallow(<Button type="primary" theme="black" />);
             expect(wrapper.exists(`${cn}_theme_green`)).toBeTruthy();
         });
+
+        it('should set classes with ellipsis', () => {
+            const wrapper = shallow(<Button ellipsis>Button text</Button>);
+
+            expect(wrapper.exists(`${cn}__content_ellipsis`)).toBeTruthy();
+            expect(wrapper.exists(`${cn}__text_ellipsis`)).toBeTruthy();
+        });
     });
 
     describe('snapshots with loader', () => {

--- a/packages/ui-core/src/components/Button/Button.tsx
+++ b/packages/ui-core/src/components/Button/Button.tsx
@@ -91,6 +91,8 @@ export interface IButtonProps {
     disabled?: boolean;
     /** Ссылка на элемент */
     buttonRef?: Ref<HTMLButtonElement | HTMLAnchorElement>;
+    /** Обрезать текст при недостаточной ширине и добавлять многоточие */
+    ellipsis?: boolean;
     /** Обработчик клика по кнопке */
     onClick?: (e: React.SyntheticEvent<EventTarget>) => void;
 }
@@ -120,6 +122,7 @@ const Button: React.FC<IButtonProps> = ({
     icon,
     disabled,
     children,
+    ellipsis = false,
     onClick,
     dataAttrs,
     buttonRef,
@@ -170,13 +173,13 @@ const Button: React.FC<IButtonProps> = ({
         }
 
         return (
-            <div {...filterDataAttrs(dataAttrs?.content)} className={cn('content', contentClassName)}>
+            <div {...filterDataAttrs(dataAttrs?.content)} className={cn('content', { ellipsis }, contentClassName)}>
                 {icon && <div className={cn('icon')}>{icon}</div>}
-                {children && <span className={cn('text')}>{children}</span>}
+                {children && <span className={cn('text', { ellipsis })}>{children}</span>}
                 {!icon && showArrow && <Arrow className={cn('icon-arrow')} />}
             </div>
         );
-    }, [children, icon, dataAttrs?.content, contentClassName, showArrow]);
+    }, [children, icon, dataAttrs?.content, contentClassName, showArrow, ellipsis]);
 
     const contentType = React.useMemo(() => {
         switch (true) {
@@ -295,6 +298,7 @@ Button.propTypes = {
         PropTypes.func,
         PropTypes.oneOfType([PropTypes.shape({ current: PropTypes.elementType }), PropTypes.any]),
     ]),
+    ellipsis: PropTypes.bool,
     onClick: PropTypes.func,
 };
 

--- a/packages/ui-core/src/components/Button/doc/Button.example.mdx
+++ b/packages/ui-core/src/components/Button/doc/Button.example.mdx
@@ -130,6 +130,13 @@ export const ref = createRef();
     <Button fullWidth>Full Width Button</Button>
 </Playground>
 
+## Сокращение текста при недостаточной ширине
+Преобразование окончания текста в многоточие будет видно при ресайзе
+
+<Playground style={blockStyle}>
+    <Button ellipsis>Long button text</Button>
+</Playground>
+
 ## Ссылка
 
 <Playground style={blockStyle}>

--- a/packages/ui-core/src/components/Notification/Notification.less
+++ b/packages/ui-core/src/components/Notification/Notification.less
@@ -55,7 +55,7 @@
     }
 
     &__text {
-        .commonFont();
+        .smallFont();
 
         position: relative;
 
@@ -65,6 +65,10 @@
         color: var(--content);
 
         transition: height 300ms;
+
+        @media @mobileBU {
+            .commonFont();
+        }
     }
 
     &__short-text {

--- a/packages/ui-core/src/components/Notification/Notification.less
+++ b/packages/ui-core/src/components/Notification/Notification.less
@@ -1,5 +1,26 @@
 @import '~styles/base';
 
+.fadeIn() {
+    position: static;
+
+    visibility: visible;
+
+    opacity: 1;
+
+    transition: opacity 200ms;
+}
+
+.fadeOut() {
+    position: absolute;
+    top: 0;
+
+    visibility: hidden;
+
+    opacity: 0;
+
+    transition: opacity 300ms, visibility 300ms;
+}
+
 @b: e('.mfui-notification');
 
 @{b} {
@@ -38,14 +59,28 @@
 
     &__text {
         .commonFont();
+
+        position: relative;
+
         max-width: 100%;
         margin: 0;
 
         color: var(--content);
+
+        transition: height 300ms;
     }
 
-    &__text_close-padding {
-        padding-right: 20px;
+    &__short-text {
+        .fadeIn();
+    }
+
+    &__short-text_hidden,
+    &__full-text {
+        .fadeOut();
+    }
+
+    &__full-text_show {
+        .fadeIn();
     }
 
     &__content {
@@ -82,17 +117,11 @@
     }
 
     &__text-container {
-        max-width: fit-content;
+        width: 85%;
+        margin-right: 56px;
 
         @media @mobileBU {
-            max-width: 540px;
-            margin-right: 160px;
-        }
-        @media @desktop {
-            max-width: 640px;
-        }
-        @media @desktopMU {
-            max-width: 840px;
+            margin-right: 72px;
         }
     }
 

--- a/packages/ui-core/src/components/Notification/Notification.less
+++ b/packages/ui-core/src/components/Notification/Notification.less
@@ -5,15 +5,14 @@
 @{b} {
     position: relative;
 
-    padding: 16px 12px;
+    padding: 20px 12px 20px 32px;
+
+    border-radius: 12px;
 
     background-color: var(--base);
 
-    @media @mobileBU {
-        padding: 20px 28px;
-    }
-    @media @desktop {
-        padding: 20px 32px;
+    @media @mobileSM {
+        padding: 16px 12px;
     }
 
     &__container {
@@ -25,6 +24,9 @@
 
         color: var(--content);
 
+        @media @mobileS {
+            line-height: 18px;
+        }
         @media @desktopMU {
             margin-bottom: 4px;
         }
@@ -51,19 +53,11 @@
         flex-direction: column;
         align-items: flex-start;
         align-self: center;
+
         width: 100%;
-        max-width: 212px;
         margin-left: 12px;
 
-        @media @mobileBU {
-            max-width: 540px;
-        }
-        @media @desktop {
-            max-width: 640px;
-        }
-        @media @desktopMU {
-            max-width: 840px;
-        }
+        overflow: hidden;
     }
 
     &__icon-container {
@@ -72,9 +66,11 @@
         align-items: center;
         align-self: flex-start;
         justify-content: center;
+
         width: 40px;
         min-width: 40px;
         height: 40px;
+
         border-radius: 50%;
     }
 
@@ -85,22 +81,119 @@
         height: 32px;
     }
 
-    &__link {
-        .h5();
-        display: inline-flex;
-        align-items: center;
-        margin-top: 8px;
+    &__text-container {
+        max-width: fit-content;
 
-        cursor: pointer;
+        @media @mobileBU {
+            max-width: 540px;
+            margin-right: 160px;
+        }
+        @media @desktop {
+            max-width: 640px;
+        }
+        @media @desktopMU {
+            max-width: 840px;
+        }
     }
 
-    &__right-arrow {
+    &__bottom {
+        display: flex;
+        gap: 16px;
+        align-items: flex-end;
+        justify-content: space-between;
+
+        width: 100%;
+        margin-top: 8px;
+
+        font-size: 12px;
+        line-height: 18px;
+
+        @media @mobileBU {
+            .h5();
+
+            gap: 20px;
+        }
+    }
+
+    &__bottom-block {
+        display: flex;
+        gap: 16px;
+
+        overflow: hidden;
+    }
+
+    &__bottom_has-button {
+        margin-top: 12px;
+    }
+
+    &__button {
+        font-weight: 500;
+    }
+
+    &__link {
+        display: inline-flex;
+        align-items: center;
+
+        cursor: pointer;
+
+        @media @mobileS {
+            line-height: 14px;
+        }
+    }
+
+    &__link-arrow,
+    &__collapse-arrow {
         width: 20px;
         min-width: 20px;
         height: 20px;
-        margin-top: 4px;
 
         fill: var(--systemBlue);
+    }
+
+    &__link-arrow {
+        margin-bottom: -2px;
+
+        @media @mobileBU {
+            margin-bottom: -4px;
+        }
+    }
+
+    &__collapse-arrow {
+        @media @mobileBU {
+            margin-top: 3px;
+        }
+    }
+
+    &__collapse-arrow_close {
+        @media @mobileBU {
+            margin-top: 2px;
+        }
+    }
+
+    &__collapse-button {
+        display: flex;
+
+        height: fit-content;
+        padding: 0;
+
+        border: none;
+
+        color: var(--systemBlue);
+
+        font-size: 12px;
+        line-height: 18px;
+
+        background-color: transparent;
+
+        cursor: pointer;
+
+        @media @mobileBU {
+            .h5();
+        }
+    }
+
+    &__collapse_hidden {
+        visibility: hidden;
     }
 
     &__close {
@@ -115,10 +208,12 @@
         width: 24px;
         height: 24px;
         padding: 0;
+
         border: none;
         border-radius: 50%;
 
-        background-color: var(--stcBlack5);
+        background-color: var(--spbSky0);
+
         cursor: pointer;
 
         @media @mobileBU {
@@ -130,11 +225,21 @@
         }
     }
 
+    &__close:hover {
+        background-color: var(--spbSky1);
+    }
+
+    &__close:active {
+        background-color: var(--spbSky2);
+    }
+
     &__close-icon {
         width: 10px;
         height: 10px;
 
-        fill: var(--stcBlack50);
+        opacity: 0.5;
+
+        fill: var(--content);
     }
 
     &_type_error {
@@ -230,7 +335,7 @@
                 color: var(--stcWhite);
             }
 
-            &__right-arrow {
+            &__link-arrow {
                 fill: var(--stcWhite);
             }
 

--- a/packages/ui-core/src/components/Notification/Notification.less
+++ b/packages/ui-core/src/components/Notification/Notification.less
@@ -241,7 +241,7 @@
         border: none;
         border-radius: 50%;
 
-        background-color: var(--spbSky0);
+        background-color: var(--stcBlack5);
 
         cursor: pointer;
 

--- a/packages/ui-core/src/components/Notification/Notification.less
+++ b/packages/ui-core/src/components/Notification/Notification.less
@@ -45,9 +45,6 @@
 
         color: var(--content);
 
-        @media @mobileS {
-            line-height: 18px;
-        }
         @media @desktopMU {
             margin-bottom: 4px;
         }
@@ -79,7 +76,7 @@
         .fadeOut();
     }
 
-    &__full-text_show {
+    &__full-text_visible {
         .fadeIn();
     }
 
@@ -126,6 +123,8 @@
     }
 
     &__bottom {
+        z-index: 1;
+
         display: flex;
         gap: 16px;
         align-items: flex-end;
@@ -134,12 +133,7 @@
         width: 100%;
         margin-top: 8px;
 
-        font-size: 12px;
-        line-height: 18px;
-
         @media @mobileBU {
-            .h5();
-
             gap: 20px;
         }
     }
@@ -155,18 +149,16 @@
         margin-top: 12px;
     }
 
-    &__button {
-        font-weight: 500;
-    }
-
     &__link {
+        .h5();
+
         display: inline-flex;
         align-items: center;
 
         cursor: pointer;
 
-        @media @mobileS {
-            line-height: 14px;
+        @media @mobileSM {
+            .smallFont();
         }
     }
 
@@ -188,6 +180,8 @@
     }
 
     &__collapse-arrow {
+        margin-top: -1px;
+
         @media @mobileBU {
             margin-top: 3px;
         }
@@ -200,6 +194,7 @@
     }
 
     &__collapse-button {
+        .h5();
         display: flex;
 
         height: fit-content;
@@ -209,15 +204,12 @@
 
         color: var(--systemBlue);
 
-        font-size: 12px;
-        line-height: 18px;
-
         background-color: transparent;
 
         cursor: pointer;
 
-        @media @mobileBU {
-            .h5();
+        @media @mobileSM {
+            .smallFont();
         }
     }
 

--- a/packages/ui-core/src/components/Notification/Notification.less
+++ b/packages/ui-core/src/components/Notification/Notification.less
@@ -183,23 +183,10 @@
         }
     }
 
-    &__collapse-arrow {
-        margin-top: -1px;
-
-        @media @mobileBU {
-            margin-top: 3px;
-        }
-    }
-
-    &__collapse-arrow_close {
-        @media @mobileBU {
-            margin-top: 2px;
-        }
-    }
-
     &__collapse-button {
         .h5();
         display: flex;
+        align-items: center;
 
         height: fit-content;
         padding: 0;
@@ -207,6 +194,7 @@
         border: none;
 
         color: var(--systemBlue);
+        text-align: right;
 
         background-color: transparent;
 

--- a/packages/ui-core/src/components/Notification/Notification.test.tsx
+++ b/packages/ui-core/src/components/Notification/Notification.test.tsx
@@ -19,6 +19,7 @@ const props: INotificationProps = {
     icon: <Attention />,
     title: 'title',
     isColored: true,
+    buttonText: 'Кнопка',
 };
 
 describe('<Notification />', () => {
@@ -29,6 +30,41 @@ describe('<Notification />', () => {
 
     it('it renders colored Notification with Props', () => {
         const wrapper = shallow(<Notification {...props}>Some test text</Notification>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('it renders Notification with close collapse', () => {
+        const wrapper = shallow(<Notification shortText="Короткий текст">Длинный текст</Notification>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('it renders Notification with custom close collapse title', () => {
+        const wrapper = shallow(
+            <Notification shortText="Короткий текст" closeCollapseTitle="Показать весь текст">
+                Длинный текст
+            </Notification>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('it renders Notification with open collapse', () => {
+        const wrapper = shallow(
+            <Notification shortText="Короткий текст" isCollapseOpened>
+                Длинный текст
+            </Notification>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('it renders Notification with custom open collapse title', () => {
+        const wrapper = shallow(
+            <Notification isCollapseOpened shortText="Короткий текст" openCollapseTitle="Скрыть часть текста">
+                Длинный текст
+            </Notification>,
+        );
+
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -46,5 +82,27 @@ describe('<Notification />', () => {
         const closeButton = wrapper.find('.mfui-notification__close');
         closeButton.simulate('click');
         expect(onClose).toBeCalled();
+    });
+
+    it('it calls onButtonClick handler', () => {
+        const onButtonClick = jest.fn();
+        const wrapper = shallow(<Notification {...props} onButtonClick={onButtonClick} />);
+        const button = wrapper.find('.mfui-notification__button');
+        button.simulate('click');
+        expect(onButtonClick).toBeCalled();
+    });
+
+    it('it calls onCollapseButtonClick handler', () => {
+        const onCollapseButtonClick = jest.fn();
+
+        const wrapper = shallow(
+            <Notification shortText="Короткий текст" onCollapseButtonClick={onCollapseButtonClick}>
+                Длинный текст
+            </Notification>,
+        );
+
+        const collapseButton = wrapper.find('.mfui-notification__collapse-button');
+        collapseButton.simulate('click');
+        expect(onCollapseButtonClick).toBeCalled();
     });
 });

--- a/packages/ui-core/src/components/Notification/Notification.test.tsx
+++ b/packages/ui-core/src/components/Notification/Notification.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Attention from '@megafon/ui-icons/system-16-attention_16.svg';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import Notification, { INotificationProps, NotificationTypes, ShadowTypes } from './Notification';
 
 const props: INotificationProps = {
@@ -12,6 +12,7 @@ const props: INotificationProps = {
     },
     type: NotificationTypes.ERROR,
     shadowLevel: ShadowTypes.HOVER,
+    link: 'Ссылка',
     href: 'href',
     hasCloseButton: false,
     rel: 'noopener',
@@ -64,6 +65,29 @@ describe('<Notification />', () => {
                 Длинный текст
             </Notification>,
         );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('it renders Notification without link, when component has collapse', () => {
+        const wrapper = shallow(
+            <Notification {...props} shortText="Короткий текст">
+                Длинный текст
+            </Notification>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('it renders Notification with close collpse after change isCollapseOpened', () => {
+        const wrapper = mount(
+            <Notification {...props} shortText="Короткий текст" isCollapseOpened>
+                Длинный текст
+            </Notification>,
+        );
+
+        wrapper.setProps({ isCollapseOpened: false });
+        wrapper.update();
 
         expect(wrapper).toMatchSnapshot();
     });

--- a/packages/ui-core/src/components/Notification/Notification.tsx
+++ b/packages/ui-core/src/components/Notification/Notification.tsx
@@ -293,7 +293,7 @@ const Notification: React.FC<INotificationProps> = ({
                                 {title}
                             </Header>
                         )}
-                        <p
+                        <div
                             ref={wrapTextRef}
                             {...filterDataAttrs(dataAttrs?.text)}
                             className={cn('text', { 'close-padding': hasCloseButton && !title })}
@@ -306,7 +306,7 @@ const Notification: React.FC<INotificationProps> = ({
                                     {children}
                                 </div>
                             )}
-                        </p>
+                        </div>
                     </div>
                     {hasBottom && (
                         <div className={cn('bottom', { 'has-button': !!buttonText })}>

--- a/packages/ui-core/src/components/Notification/Notification.tsx
+++ b/packages/ui-core/src/components/Notification/Notification.tsx
@@ -1,11 +1,15 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { cnCreate, filterDataAttrs } from '@megafon/ui-helpers';
 import ErrorIcon from '@megafon/ui-icons/basic-24-block_24.svg';
+import ArrowDown from '@megafon/ui-icons/system-16-arrow-list_down_16.svg';
+import ArrowUp from '@megafon/ui-icons/system-16-arrow-list_up_16.svg';
 import RightArrow from '@megafon/ui-icons/system-16-arrow_right_16.svg';
 import WarningIcon from '@megafon/ui-icons/system-24-attention_invert_24.svg';
 import SuccessIcon from '@megafon/ui-icons/system-24-checked_24.svg';
 import InfoIcon from '@megafon/ui-icons/system-24-info_invert_24.svg';
 import * as PropTypes from 'prop-types';
+import Button from 'components/Button/Button';
+import Collapse from 'components/Collapse/Collapse';
 import Header from 'components/Header/Header';
 import TextLink from 'components/TextLink/TextLink';
 import Tile from 'components/Tile/Tile';
@@ -49,6 +53,20 @@ export interface INotificationProps {
     hasCloseButton?: boolean;
     /** Заголовок */
     title?: string;
+    /** Короткий текст, отображаемый при закрытом расхлопе */
+    shortText?: string;
+    /** заголовок закрытого расхлопа */
+    closeCollapseTitle?: string;
+    /** заголовок открытого расхлопа */
+    openCollapseTitle?: string;
+    /** Управление состоянием открыт/закрыт расхлопа "Подробнее" */
+    isCollapseOpened?: boolean;
+    /** Текст кнопки */
+    buttonText?: string;
+    /** Лоадер кнопки */
+    buttonLoader?: boolean;
+    /** Заблокировать кнопку */
+    buttonDisable?: boolean;
     /** Текст ссылки внизу уведомления */
     link?: string;
     /** rel - аргумент тега <a> для ссылки */
@@ -66,11 +84,17 @@ export interface INotificationProps {
         text?: Record<string, string>;
         link?: Record<string, string>;
         close?: Record<string, string>;
+        button?: Record<string, string>;
+        collapseButton?: Record<string, string>;
     };
     /** Обработчик на закрытие */
     onClose?: () => void;
     /** Обработчик клика по ссылке */
     onLinkClick?: () => void;
+    /** Обработчик клика по кнопке */
+    onButtonClick?: () => void;
+    /** Обработчик клика по кнопке расхлопа */
+    onCollapseButtonClick?: (value: boolean) => void;
 }
 
 const cn = cnCreate('mfui-notification');
@@ -83,6 +107,13 @@ const Notification: React.FC<INotificationProps> = ({
     isColored = true,
     hasCloseButton,
     title,
+    shortText,
+    closeCollapseTitle = 'Подробнее',
+    openCollapseTitle = 'Свернуть',
+    isCollapseOpened = false,
+    buttonText,
+    buttonLoader = false,
+    buttonDisable = false,
     link,
     rel,
     href,
@@ -91,7 +122,23 @@ const Notification: React.FC<INotificationProps> = ({
     dataAttrs,
     onClose,
     onLinkClick,
+    onButtonClick,
+    onCollapseButtonClick,
 }) => {
+    const [showFullText, setShowFullText] = useState(isCollapseOpened);
+
+    const hasBottom = shortText || buttonText || link;
+    const isErrorType = type === NotificationTypes.ERROR;
+
+    useEffect(() => {
+        setShowFullText(isCollapseOpened);
+    }, [isCollapseOpened]);
+
+    const handleCollapseButtonClick = (): void => {
+        setShowFullText(!showFullText);
+        onCollapseButtonClick?.(!showFullText);
+    };
+
     const renderLink = (): JSX.Element => (
         <TextLink
             dataAttrs={{ root: dataAttrs?.link }}
@@ -102,8 +149,38 @@ const Notification: React.FC<INotificationProps> = ({
             target={target}
         >
             {link}
-            <RightArrow className={cn('right-arrow')} />
+            <RightArrow className={cn('link-arrow')} />
         </TextLink>
+    );
+
+    const renderButton = (): JSX.Element => (
+        <Button
+            className={cn('button')}
+            dataAttrs={{ root: dataAttrs?.button }}
+            sizeAll="small"
+            sizeMobile="extra-small"
+            theme={isErrorType && isColored ? 'white' : 'green'}
+            showLoader={buttonLoader}
+            disabled={buttonDisable}
+            ellipsis={!buttonLoader}
+            onClick={onButtonClick}
+        >
+            {buttonText}
+        </Button>
+    );
+
+    const renderCollapseButton = (): JSX.Element => (
+        <button
+            {...filterDataAttrs(dataAttrs?.collapseButton)}
+            type="button"
+            className={cn('collapse-button')}
+            onClick={handleCollapseButtonClick}
+        >
+            {showFullText ? openCollapseTitle : closeCollapseTitle}
+            <div className={cn('collapse-arrow', { close: showFullText })}>
+                {showFullText ? <ArrowUp /> : <ArrowDown />}
+            </div>
+        </button>
     );
 
     const renderIcon = (): JSX.Element => {
@@ -140,24 +217,44 @@ const Notification: React.FC<INotificationProps> = ({
         >
             <div className={cn('container', [containerClass])}>
                 <div className={cn('icon-container')}>{renderIcon()}</div>
-
                 <div className={cn('content', [contentClass])}>
-                    {title && (
-                        <Header
-                            dataAttrs={{ root: dataAttrs?.title }}
-                            as="h5"
-                            className={cn('title', { 'close-padding': hasCloseButton })}
+                    <div className={cn('text-container')}>
+                        {title && (
+                            <Header
+                                dataAttrs={{ root: dataAttrs?.title }}
+                                as="h5"
+                                className={cn('title', { 'close-padding': hasCloseButton })}
+                            >
+                                {title}
+                            </Header>
+                        )}
+                        <p
+                            {...filterDataAttrs(dataAttrs?.text)}
+                            className={cn('text', { 'close-padding': hasCloseButton && !title })}
                         >
-                            {title}
-                        </Header>
+                            {!showFullText && (shortText || children)}
+                            {shortText && (
+                                <Collapse
+                                    className={cn('collapse', { hidden: !showFullText })}
+                                    classNameContainer={cn('collapse-inner')}
+                                    isOpened={showFullText}
+                                >
+                                    {children}
+                                </Collapse>
+                            )}
+                        </p>
+                    </div>
+                    {hasBottom && (
+                        <div className={cn('bottom', { 'has-button': !!buttonText })}>
+                            {(buttonText || link) && (
+                                <div className={cn('bottom-block')}>
+                                    {buttonText && renderButton()}
+                                    {link && !shortText && renderLink()}
+                                </div>
+                            )}
+                            {shortText && renderCollapseButton()}
+                        </div>
                     )}
-                    <p
-                        {...filterDataAttrs(dataAttrs?.text)}
-                        className={cn('text', { 'close-padding': hasCloseButton && !title })}
-                    >
-                        {children}
-                    </p>
-                    {link && renderLink()}
                 </div>
             </div>
             {hasCloseButton && (
@@ -181,6 +278,13 @@ Notification.propTypes = {
     isColored: PropTypes.bool,
     hasCloseButton: PropTypes.bool,
     title: PropTypes.string,
+    shortText: PropTypes.string,
+    closeCollapseTitle: PropTypes.string,
+    openCollapseTitle: PropTypes.string,
+    isCollapseOpened: PropTypes.bool,
+    buttonText: PropTypes.string,
+    buttonLoader: PropTypes.bool,
+    buttonDisable: PropTypes.bool,
     link: PropTypes.string,
     rel: PropTypes.string,
     href: PropTypes.string,
@@ -192,8 +296,12 @@ Notification.propTypes = {
         text: PropTypes.objectOf(PropTypes.string.isRequired),
         link: PropTypes.objectOf(PropTypes.string.isRequired),
         close: PropTypes.objectOf(PropTypes.string.isRequired),
+        button: PropTypes.objectOf(PropTypes.string.isRequired),
+        collapseButton: PropTypes.objectOf(PropTypes.string.isRequired),
     }),
     onClose: PropTypes.func,
     onLinkClick: PropTypes.func,
+    onButtonClick: PropTypes.func,
+    onCollapseButtonClick: PropTypes.func,
 };
 export default Notification;

--- a/packages/ui-core/src/components/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/packages/ui-core/src/components/Notification/__snapshots__/Notification.test.tsx.snap
@@ -1,5 +1,239 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Notification /> it renders Notification with close collapse 1`] = `
+<Tile
+  className="mfui-notification mfui-notification_type_info mfui-notification_colored"
+  dataAttrs={
+    Object {
+      "root": undefined,
+    }
+  }
+  radius="rounded"
+  shadowLevel="zero"
+>
+  <div
+    className="mfui-notification__container"
+  >
+    <div
+      className="mfui-notification__icon-container"
+    >
+      <test-file-stub />
+    </div>
+    <div
+      className="mfui-notification__content"
+    >
+      <div
+        className="mfui-notification__text-container"
+      >
+        <p
+          className="mfui-notification__text"
+        >
+          Короткий текст
+          <Collapse
+            className="mfui-notification__collapse mfui-notification__collapse_hidden"
+            classNameContainer="mfui-notification__collapse-inner"
+            isOpened={false}
+          >
+            Длинный текст
+          </Collapse>
+        </p>
+      </div>
+      <div
+        className="mfui-notification__bottom"
+      >
+        <button
+          className="mfui-notification__collapse-button"
+          onClick={[Function]}
+          type="button"
+        >
+          Подробнее
+          <div
+            className="mfui-notification__collapse-arrow"
+          >
+            <test-file-stub />
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</Tile>
+`;
+
+exports[`<Notification /> it renders Notification with custom close collapse title 1`] = `
+<Tile
+  className="mfui-notification mfui-notification_type_info mfui-notification_colored"
+  dataAttrs={
+    Object {
+      "root": undefined,
+    }
+  }
+  radius="rounded"
+  shadowLevel="zero"
+>
+  <div
+    className="mfui-notification__container"
+  >
+    <div
+      className="mfui-notification__icon-container"
+    >
+      <test-file-stub />
+    </div>
+    <div
+      className="mfui-notification__content"
+    >
+      <div
+        className="mfui-notification__text-container"
+      >
+        <p
+          className="mfui-notification__text"
+        >
+          Короткий текст
+          <Collapse
+            className="mfui-notification__collapse mfui-notification__collapse_hidden"
+            classNameContainer="mfui-notification__collapse-inner"
+            isOpened={false}
+          >
+            Длинный текст
+          </Collapse>
+        </p>
+      </div>
+      <div
+        className="mfui-notification__bottom"
+      >
+        <button
+          className="mfui-notification__collapse-button"
+          onClick={[Function]}
+          type="button"
+        >
+          Показать весь текст
+          <div
+            className="mfui-notification__collapse-arrow"
+          >
+            <test-file-stub />
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</Tile>
+`;
+
+exports[`<Notification /> it renders Notification with custom open collapse title 1`] = `
+<Tile
+  className="mfui-notification mfui-notification_type_info mfui-notification_colored"
+  dataAttrs={
+    Object {
+      "root": undefined,
+    }
+  }
+  radius="rounded"
+  shadowLevel="zero"
+>
+  <div
+    className="mfui-notification__container"
+  >
+    <div
+      className="mfui-notification__icon-container"
+    >
+      <test-file-stub />
+    </div>
+    <div
+      className="mfui-notification__content"
+    >
+      <div
+        className="mfui-notification__text-container"
+      >
+        <p
+          className="mfui-notification__text"
+        >
+          <Collapse
+            className="mfui-notification__collapse"
+            classNameContainer="mfui-notification__collapse-inner"
+            isOpened={true}
+          >
+            Длинный текст
+          </Collapse>
+        </p>
+      </div>
+      <div
+        className="mfui-notification__bottom"
+      >
+        <button
+          className="mfui-notification__collapse-button"
+          onClick={[Function]}
+          type="button"
+        >
+          Скрыть часть текста
+          <div
+            className="mfui-notification__collapse-arrow mfui-notification__collapse-arrow_close"
+          >
+            <test-file-stub />
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</Tile>
+`;
+
+exports[`<Notification /> it renders Notification with open collapse 1`] = `
+<Tile
+  className="mfui-notification mfui-notification_type_info mfui-notification_colored"
+  dataAttrs={
+    Object {
+      "root": undefined,
+    }
+  }
+  radius="rounded"
+  shadowLevel="zero"
+>
+  <div
+    className="mfui-notification__container"
+  >
+    <div
+      className="mfui-notification__icon-container"
+    >
+      <test-file-stub />
+    </div>
+    <div
+      className="mfui-notification__content"
+    >
+      <div
+        className="mfui-notification__text-container"
+      >
+        <p
+          className="mfui-notification__text"
+        >
+          <Collapse
+            className="mfui-notification__collapse"
+            classNameContainer="mfui-notification__collapse-inner"
+            isOpened={true}
+          >
+            Длинный текст
+          </Collapse>
+        </p>
+      </div>
+      <div
+        className="mfui-notification__bottom"
+      >
+        <button
+          className="mfui-notification__collapse-button"
+          onClick={[Function]}
+          type="button"
+        >
+          Свернуть
+          <div
+            className="mfui-notification__collapse-arrow mfui-notification__collapse-arrow_close"
+          >
+            <test-file-stub />
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</Tile>
+`;
+
 exports[`<Notification /> it renders colored Notification with Props 1`] = `
 <Tile
   className="mfui-notification mfui-notification_type_error mfui-notification_colored notification rootClass"
@@ -22,22 +256,50 @@ exports[`<Notification /> it renders colored Notification with Props 1`] = `
     <div
       className="mfui-notification__content contentClass"
     >
-      <Header
-        as="h5"
-        className="mfui-notification__title"
-        dataAttrs={
-          Object {
-            "root": undefined,
+      <div
+        className="mfui-notification__text-container"
+      >
+        <Header
+          as="h5"
+          className="mfui-notification__title"
+          dataAttrs={
+            Object {
+              "root": undefined,
+            }
           }
-        }
+        >
+          title
+        </Header>
+        <p
+          className="mfui-notification__text"
+        >
+          Some test text
+        </p>
+      </div>
+      <div
+        className="mfui-notification__bottom mfui-notification__bottom_has-button"
       >
-        title
-      </Header>
-      <p
-        className="mfui-notification__text"
-      >
-        Some test text
-      </p>
+        <div
+          className="mfui-notification__bottom-block"
+        >
+          <Button
+            className="mfui-notification__button"
+            dataAttrs={
+              Object {
+                "root": undefined,
+              }
+            }
+            disabled={false}
+            ellipsis={true}
+            showLoader={false}
+            sizeAll="small"
+            sizeMobile="extra-small"
+            theme="white"
+          >
+            Кнопка
+          </Button>
+        </div>
+      </div>
     </div>
   </div>
 </Tile>
@@ -65,11 +327,15 @@ exports[`<Notification /> renders component 1`] = `
     <div
       className="mfui-notification__content"
     >
-      <p
-        className="mfui-notification__text"
+      <div
+        className="mfui-notification__text-container"
       >
-        Some test text
-      </p>
+        <p
+          className="mfui-notification__text"
+        >
+          Some test text
+        </p>
+      </div>
     </div>
   </div>
 </Tile>

--- a/packages/ui-core/src/components/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/packages/ui-core/src/components/Notification/__snapshots__/Notification.test.tsx.snap
@@ -28,14 +28,16 @@ exports[`<Notification /> it renders Notification with close collapse 1`] = `
         <p
           className="mfui-notification__text"
         >
-          Короткий текст
-          <Collapse
-            className="mfui-notification__collapse mfui-notification__collapse_hidden"
-            classNameContainer="mfui-notification__collapse-inner"
-            isOpened={false}
+          <div
+            className="mfui-notification__short-text"
+          >
+            Короткий текст
+          </div>
+          <div
+            className="mfui-notification__full-text"
           >
             Длинный текст
-          </Collapse>
+          </div>
         </p>
       </div>
       <div
@@ -87,14 +89,16 @@ exports[`<Notification /> it renders Notification with custom close collapse tit
         <p
           className="mfui-notification__text"
         >
-          Короткий текст
-          <Collapse
-            className="mfui-notification__collapse mfui-notification__collapse_hidden"
-            classNameContainer="mfui-notification__collapse-inner"
-            isOpened={false}
+          <div
+            className="mfui-notification__short-text"
+          >
+            Короткий текст
+          </div>
+          <div
+            className="mfui-notification__full-text"
           >
             Длинный текст
-          </Collapse>
+          </div>
         </p>
       </div>
       <div
@@ -146,13 +150,16 @@ exports[`<Notification /> it renders Notification with custom open collapse titl
         <p
           className="mfui-notification__text"
         >
-          <Collapse
-            className="mfui-notification__collapse"
-            classNameContainer="mfui-notification__collapse-inner"
-            isOpened={true}
+          <div
+            className="mfui-notification__short-text mfui-notification__short-text_hidden"
+          >
+            Короткий текст
+          </div>
+          <div
+            className="mfui-notification__full-text mfui-notification__full-text_show"
           >
             Длинный текст
-          </Collapse>
+          </div>
         </p>
       </div>
       <div
@@ -204,13 +211,16 @@ exports[`<Notification /> it renders Notification with open collapse 1`] = `
         <p
           className="mfui-notification__text"
         >
-          <Collapse
-            className="mfui-notification__collapse"
-            classNameContainer="mfui-notification__collapse-inner"
-            isOpened={true}
+          <div
+            className="mfui-notification__short-text mfui-notification__short-text_hidden"
+          >
+            Короткий текст
+          </div>
+          <div
+            className="mfui-notification__full-text mfui-notification__full-text_show"
           >
             Длинный текст
-          </Collapse>
+          </div>
         </p>
       </div>
       <div
@@ -224,6 +234,243 @@ exports[`<Notification /> it renders Notification with open collapse 1`] = `
           Свернуть
           <div
             className="mfui-notification__collapse-arrow mfui-notification__collapse-arrow_close"
+          >
+            <test-file-stub />
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</Tile>
+`;
+
+exports[`<Notification /> it renders Notification without close collpse after change isCollapseOpened 1`] = `
+<Notification
+  buttonText="Кнопка"
+  className="notification"
+  classes={
+    Object {
+      "container": "containerClass",
+      "content": "contentClass",
+      "root": "rootClass",
+    }
+  }
+  hasCloseButton={false}
+  href="href"
+  icon={<test-file-stub />}
+  isCollapseOpened={false}
+  isColored={true}
+  link="Ссылка"
+  rel="noopener"
+  shadowLevel="hover"
+  shortText="Короткий текст"
+  target="_blank"
+  title="title"
+  type="error"
+>
+  <Tile
+    className="mfui-notification mfui-notification_type_error mfui-notification_colored notification rootClass"
+    dataAttrs={
+      Object {
+        "root": undefined,
+      }
+    }
+    radius="rounded"
+    shadowLevel="hover"
+  >
+    <div
+      className="mfui-tile mfui-tile_theme_light mfui-tile_radius_rounded mfui-tile_shadow_hover mfui-notification mfui-notification_type_error mfui-notification_colored notification rootClass"
+      onClick={[Function]}
+    >
+      <div
+        className="mfui-notification__container containerClass"
+      >
+        <div
+          className="mfui-notification__icon-container"
+        >
+          <test-file-stub />
+        </div>
+        <div
+          className="mfui-notification__content contentClass"
+        >
+          <div
+            className="mfui-notification__text-container"
+          >
+            <Header
+              as="h5"
+              className="mfui-notification__title"
+              dataAttrs={
+                Object {
+                  "root": undefined,
+                }
+              }
+            >
+              <h5
+                className="mfui-header mfui-header_color_default mfui-header_level_h5 mfui-header_h-align_inherit mfui-notification__title"
+              >
+                title
+              </h5>
+            </Header>
+            <p
+              className="mfui-notification__text"
+            >
+              <div
+                className="mfui-notification__short-text"
+              >
+                Короткий текст
+              </div>
+              <div
+                className="mfui-notification__full-text"
+              >
+                Длинный текст
+              </div>
+            </p>
+          </div>
+          <div
+            className="mfui-notification__bottom mfui-notification__bottom_has-button"
+          >
+            <div
+              className="mfui-notification__bottom-block"
+            >
+              <Button
+                className="mfui-notification__button"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
+                disabled={false}
+                ellipsis={true}
+                showLoader={false}
+                sizeAll="small"
+                sizeMobile="extra-small"
+                theme="white"
+              >
+                <button
+                  className="mfui-button mfui-button_type_primary mfui-button_theme_white mfui-button_size-all_small mfui-button_size-mobile_extra-small mfui-button_no-touch mfui-button_content-type_text mfui-notification__button"
+                  disabled={false}
+                  download={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className="mfui-button__inner"
+                  >
+                    <div
+                      className="mfui-button__content mfui-button__content_ellipsis"
+                    >
+                      <span
+                        className="mfui-button__text mfui-button__text_ellipsis"
+                      >
+                        Кнопка
+                      </span>
+                    </div>
+                  </div>
+                </button>
+              </Button>
+            </div>
+            <button
+              className="mfui-notification__collapse-button"
+              onClick={[Function]}
+              type="button"
+            >
+              Подробнее
+              <div
+                className="mfui-notification__collapse-arrow"
+              >
+                <test-file-stub />
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Tile>
+</Notification>
+`;
+
+exports[`<Notification /> it renders Notification without link, when component has collapse 1`] = `
+<Tile
+  className="mfui-notification mfui-notification_type_error mfui-notification_colored notification rootClass"
+  dataAttrs={
+    Object {
+      "root": undefined,
+    }
+  }
+  radius="rounded"
+  shadowLevel="hover"
+>
+  <div
+    className="mfui-notification__container containerClass"
+  >
+    <div
+      className="mfui-notification__icon-container"
+    >
+      <test-file-stub />
+    </div>
+    <div
+      className="mfui-notification__content contentClass"
+    >
+      <div
+        className="mfui-notification__text-container"
+      >
+        <Header
+          as="h5"
+          className="mfui-notification__title"
+          dataAttrs={
+            Object {
+              "root": undefined,
+            }
+          }
+        >
+          title
+        </Header>
+        <p
+          className="mfui-notification__text"
+        >
+          <div
+            className="mfui-notification__short-text"
+          >
+            Короткий текст
+          </div>
+          <div
+            className="mfui-notification__full-text"
+          >
+            Длинный текст
+          </div>
+        </p>
+      </div>
+      <div
+        className="mfui-notification__bottom mfui-notification__bottom_has-button"
+      >
+        <div
+          className="mfui-notification__bottom-block"
+        >
+          <Button
+            className="mfui-notification__button"
+            dataAttrs={
+              Object {
+                "root": undefined,
+              }
+            }
+            disabled={false}
+            ellipsis={true}
+            showLoader={false}
+            sizeAll="small"
+            sizeMobile="extra-small"
+            theme="white"
+          >
+            Кнопка
+          </Button>
+        </div>
+        <button
+          className="mfui-notification__collapse-button"
+          onClick={[Function]}
+          type="button"
+        >
+          Подробнее
+          <div
+            className="mfui-notification__collapse-arrow"
           >
             <test-file-stub />
           </div>
@@ -273,7 +520,11 @@ exports[`<Notification /> it renders colored Notification with Props 1`] = `
         <p
           className="mfui-notification__text"
         >
-          Some test text
+          <div
+            className="mfui-notification__short-text"
+          >
+            Some test text
+          </div>
         </p>
       </div>
       <div
@@ -298,6 +549,22 @@ exports[`<Notification /> it renders colored Notification with Props 1`] = `
           >
             Кнопка
           </Button>
+          <TextLink
+            className="mfui-notification__link"
+            dataAttrs={
+              Object {
+                "root": undefined,
+              }
+            }
+            href="href"
+            rel="noopener"
+            target="_blank"
+          >
+            Ссылка
+            <test-file-stub
+              className="mfui-notification__link-arrow"
+            />
+          </TextLink>
         </div>
       </div>
     </div>
@@ -333,7 +600,11 @@ exports[`<Notification /> renders component 1`] = `
         <p
           className="mfui-notification__text"
         >
-          Some test text
+          <div
+            className="mfui-notification__short-text"
+          >
+            Some test text
+          </div>
         </p>
       </div>
     </div>

--- a/packages/ui-core/src/components/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/packages/ui-core/src/components/Notification/__snapshots__/Notification.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`<Notification /> it renders Notification with close collapse 1`] = `
       <div
         className="mfui-notification__text-container"
       >
-        <p
+        <div
           className="mfui-notification__text"
         >
           <div
@@ -38,7 +38,7 @@ exports[`<Notification /> it renders Notification with close collapse 1`] = `
           >
             Длинный текст
           </div>
-        </p>
+        </div>
       </div>
       <div
         className="mfui-notification__bottom"
@@ -128,7 +128,7 @@ exports[`<Notification /> it renders Notification with close collpse after chang
                 title
               </h5>
             </Header>
-            <p
+            <div
               className="mfui-notification__text"
             >
               <div
@@ -141,7 +141,7 @@ exports[`<Notification /> it renders Notification with close collpse after chang
               >
                 Длинный текст
               </div>
-            </p>
+            </div>
           </div>
           <div
             className="mfui-notification__bottom mfui-notification__bottom_has-button"
@@ -231,7 +231,7 @@ exports[`<Notification /> it renders Notification with custom close collapse tit
       <div
         className="mfui-notification__text-container"
       >
-        <p
+        <div
           className="mfui-notification__text"
         >
           <div
@@ -244,7 +244,7 @@ exports[`<Notification /> it renders Notification with custom close collapse tit
           >
             Длинный текст
           </div>
-        </p>
+        </div>
       </div>
       <div
         className="mfui-notification__bottom"
@@ -292,7 +292,7 @@ exports[`<Notification /> it renders Notification with custom open collapse titl
       <div
         className="mfui-notification__text-container"
       >
-        <p
+        <div
           className="mfui-notification__text"
         >
           <div
@@ -305,7 +305,7 @@ exports[`<Notification /> it renders Notification with custom open collapse titl
           >
             Длинный текст
           </div>
-        </p>
+        </div>
       </div>
       <div
         className="mfui-notification__bottom"
@@ -353,7 +353,7 @@ exports[`<Notification /> it renders Notification with open collapse 1`] = `
       <div
         className="mfui-notification__text-container"
       >
-        <p
+        <div
           className="mfui-notification__text"
         >
           <div
@@ -366,7 +366,7 @@ exports[`<Notification /> it renders Notification with open collapse 1`] = `
           >
             Длинный текст
           </div>
-        </p>
+        </div>
       </div>
       <div
         className="mfui-notification__bottom"
@@ -425,7 +425,7 @@ exports[`<Notification /> it renders Notification without link, when component h
         >
           title
         </Header>
-        <p
+        <div
           className="mfui-notification__text"
         >
           <div
@@ -438,7 +438,7 @@ exports[`<Notification /> it renders Notification without link, when component h
           >
             Длинный текст
           </div>
-        </p>
+        </div>
       </div>
       <div
         className="mfui-notification__bottom mfui-notification__bottom_has-button"
@@ -517,7 +517,7 @@ exports[`<Notification /> it renders colored Notification with Props 1`] = `
         >
           title
         </Header>
-        <p
+        <div
           className="mfui-notification__text"
         >
           <div
@@ -525,7 +525,7 @@ exports[`<Notification /> it renders colored Notification with Props 1`] = `
           >
             Some test text
           </div>
-        </p>
+        </div>
       </div>
       <div
         className="mfui-notification__bottom mfui-notification__bottom_has-button"
@@ -597,7 +597,7 @@ exports[`<Notification /> renders component 1`] = `
       <div
         className="mfui-notification__text-container"
       >
-        <p
+        <div
           className="mfui-notification__text"
         >
           <div
@@ -605,7 +605,7 @@ exports[`<Notification /> renders component 1`] = `
           >
             Some test text
           </div>
-        </p>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/ui-core/src/components/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/packages/ui-core/src/components/Notification/__snapshots__/Notification.test.tsx.snap
@@ -61,6 +61,151 @@ exports[`<Notification /> it renders Notification with close collapse 1`] = `
 </Tile>
 `;
 
+exports[`<Notification /> it renders Notification with close collpse after change isCollapseOpened 1`] = `
+<Notification
+  buttonText="Кнопка"
+  className="notification"
+  classes={
+    Object {
+      "container": "containerClass",
+      "content": "contentClass",
+      "root": "rootClass",
+    }
+  }
+  hasCloseButton={false}
+  href="href"
+  icon={<test-file-stub />}
+  isCollapseOpened={false}
+  isColored={true}
+  link="Ссылка"
+  rel="noopener"
+  shadowLevel="hover"
+  shortText="Короткий текст"
+  target="_blank"
+  title="title"
+  type="error"
+>
+  <Tile
+    className="mfui-notification mfui-notification_type_error mfui-notification_colored notification rootClass"
+    dataAttrs={
+      Object {
+        "root": undefined,
+      }
+    }
+    radius="rounded"
+    shadowLevel="hover"
+  >
+    <div
+      className="mfui-tile mfui-tile_theme_light mfui-tile_radius_rounded mfui-tile_shadow_hover mfui-notification mfui-notification_type_error mfui-notification_colored notification rootClass"
+      onClick={[Function]}
+    >
+      <div
+        className="mfui-notification__container containerClass"
+      >
+        <div
+          className="mfui-notification__icon-container"
+        >
+          <test-file-stub />
+        </div>
+        <div
+          className="mfui-notification__content contentClass"
+        >
+          <div
+            className="mfui-notification__text-container"
+          >
+            <Header
+              as="h5"
+              className="mfui-notification__title"
+              dataAttrs={
+                Object {
+                  "root": undefined,
+                }
+              }
+            >
+              <h5
+                className="mfui-header mfui-header_color_default mfui-header_level_h5 mfui-header_h-align_inherit mfui-notification__title"
+              >
+                title
+              </h5>
+            </Header>
+            <p
+              className="mfui-notification__text"
+            >
+              <div
+                className="mfui-notification__short-text"
+              >
+                Короткий текст
+              </div>
+              <div
+                className="mfui-notification__full-text"
+              >
+                Длинный текст
+              </div>
+            </p>
+          </div>
+          <div
+            className="mfui-notification__bottom mfui-notification__bottom_has-button"
+          >
+            <div
+              className="mfui-notification__bottom-block"
+            >
+              <Button
+                className="mfui-notification__button"
+                dataAttrs={
+                  Object {
+                    "root": undefined,
+                  }
+                }
+                disabled={false}
+                ellipsis={true}
+                showLoader={false}
+                sizeAll="small"
+                sizeMobile="extra-small"
+                theme="white"
+              >
+                <button
+                  className="mfui-button mfui-button_type_primary mfui-button_theme_white mfui-button_size-all_small mfui-button_size-mobile_extra-small mfui-button_no-touch mfui-button_content-type_text mfui-notification__button"
+                  disabled={false}
+                  download={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className="mfui-button__inner"
+                  >
+                    <div
+                      className="mfui-button__content mfui-button__content_ellipsis"
+                    >
+                      <span
+                        className="mfui-button__text mfui-button__text_ellipsis"
+                      >
+                        Кнопка
+                      </span>
+                    </div>
+                  </div>
+                </button>
+              </Button>
+            </div>
+            <button
+              className="mfui-notification__collapse-button"
+              onClick={[Function]}
+              type="button"
+            >
+              Подробнее
+              <div
+                className="mfui-notification__collapse-arrow"
+              >
+                <test-file-stub />
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Tile>
+</Notification>
+`;
+
 exports[`<Notification /> it renders Notification with custom close collapse title 1`] = `
 <Tile
   className="mfui-notification mfui-notification_type_info mfui-notification_colored"
@@ -242,151 +387,6 @@ exports[`<Notification /> it renders Notification with open collapse 1`] = `
     </div>
   </div>
 </Tile>
-`;
-
-exports[`<Notification /> it renders Notification without close collpse after change isCollapseOpened 1`] = `
-<Notification
-  buttonText="Кнопка"
-  className="notification"
-  classes={
-    Object {
-      "container": "containerClass",
-      "content": "contentClass",
-      "root": "rootClass",
-    }
-  }
-  hasCloseButton={false}
-  href="href"
-  icon={<test-file-stub />}
-  isCollapseOpened={false}
-  isColored={true}
-  link="Ссылка"
-  rel="noopener"
-  shadowLevel="hover"
-  shortText="Короткий текст"
-  target="_blank"
-  title="title"
-  type="error"
->
-  <Tile
-    className="mfui-notification mfui-notification_type_error mfui-notification_colored notification rootClass"
-    dataAttrs={
-      Object {
-        "root": undefined,
-      }
-    }
-    radius="rounded"
-    shadowLevel="hover"
-  >
-    <div
-      className="mfui-tile mfui-tile_theme_light mfui-tile_radius_rounded mfui-tile_shadow_hover mfui-notification mfui-notification_type_error mfui-notification_colored notification rootClass"
-      onClick={[Function]}
-    >
-      <div
-        className="mfui-notification__container containerClass"
-      >
-        <div
-          className="mfui-notification__icon-container"
-        >
-          <test-file-stub />
-        </div>
-        <div
-          className="mfui-notification__content contentClass"
-        >
-          <div
-            className="mfui-notification__text-container"
-          >
-            <Header
-              as="h5"
-              className="mfui-notification__title"
-              dataAttrs={
-                Object {
-                  "root": undefined,
-                }
-              }
-            >
-              <h5
-                className="mfui-header mfui-header_color_default mfui-header_level_h5 mfui-header_h-align_inherit mfui-notification__title"
-              >
-                title
-              </h5>
-            </Header>
-            <p
-              className="mfui-notification__text"
-            >
-              <div
-                className="mfui-notification__short-text"
-              >
-                Короткий текст
-              </div>
-              <div
-                className="mfui-notification__full-text"
-              >
-                Длинный текст
-              </div>
-            </p>
-          </div>
-          <div
-            className="mfui-notification__bottom mfui-notification__bottom_has-button"
-          >
-            <div
-              className="mfui-notification__bottom-block"
-            >
-              <Button
-                className="mfui-notification__button"
-                dataAttrs={
-                  Object {
-                    "root": undefined,
-                  }
-                }
-                disabled={false}
-                ellipsis={true}
-                showLoader={false}
-                sizeAll="small"
-                sizeMobile="extra-small"
-                theme="white"
-              >
-                <button
-                  className="mfui-button mfui-button_type_primary mfui-button_theme_white mfui-button_size-all_small mfui-button_size-mobile_extra-small mfui-button_no-touch mfui-button_content-type_text mfui-notification__button"
-                  disabled={false}
-                  download={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <div
-                    className="mfui-button__inner"
-                  >
-                    <div
-                      className="mfui-button__content mfui-button__content_ellipsis"
-                    >
-                      <span
-                        className="mfui-button__text mfui-button__text_ellipsis"
-                      >
-                        Кнопка
-                      </span>
-                    </div>
-                  </div>
-                </button>
-              </Button>
-            </div>
-            <button
-              className="mfui-notification__collapse-button"
-              onClick={[Function]}
-              type="button"
-            >
-              Подробнее
-              <div
-                className="mfui-notification__collapse-arrow"
-              >
-                <test-file-stub />
-              </div>
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  </Tile>
-</Notification>
 `;
 
 exports[`<Notification /> it renders Notification without link, when component has collapse 1`] = `

--- a/packages/ui-core/src/components/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/packages/ui-core/src/components/Notification/__snapshots__/Notification.test.tsx.snap
@@ -301,7 +301,7 @@ exports[`<Notification /> it renders Notification with custom open collapse titl
             Короткий текст
           </div>
           <div
-            className="mfui-notification__full-text mfui-notification__full-text_show"
+            className="mfui-notification__full-text mfui-notification__full-text_visible"
           >
             Длинный текст
           </div>
@@ -362,7 +362,7 @@ exports[`<Notification /> it renders Notification with open collapse 1`] = `
             Короткий текст
           </div>
           <div
-            className="mfui-notification__full-text mfui-notification__full-text_show"
+            className="mfui-notification__full-text mfui-notification__full-text_visible"
           >
             Длинный текст
           </div>

--- a/packages/ui-core/src/components/Notification/doc/Notification.docz.tsx
+++ b/packages/ui-core/src/components/Notification/doc/Notification.docz.tsx
@@ -10,8 +10,17 @@ export const wrapperStyle = {
 };
 
 interface IDemoNotificationWrapperProps {
-    children: (prop: { onClose?: () => void; onLinkClick?: () => void; initialClickAmount: number }) => JSX.Element;
-    initialClickAmount: number;
+    children: (prop: {
+        onClose: () => void;
+        onLinkClick: () => void;
+        onButtonClick: () => void;
+        onWrapperButtonClick: () => void;
+        onCollapseButtonClick: (value: boolean) => void;
+        initialClickAmount: number;
+        isCollapseOpen: boolean;
+    }) => JSX.Element;
+    initialClickAmount?: number;
+    initialButtonClickAmount?: number;
 }
 
 export const DemoNotificationWrapper: React.FC<IDemoNotificationWrapperProps> = ({
@@ -19,10 +28,15 @@ export const DemoNotificationWrapper: React.FC<IDemoNotificationWrapperProps> = 
     children,
 }) => {
     const [clickAmount, setClickAmount] = useState(initialClickAmount);
+    const [isCollapseOpen, setIsCollapseOpen] = useState(true);
 
     return children({
+        onCollapseButtonClick: (value: boolean) => setIsCollapseOpen(value),
+        onWrapperButtonClick: () => setIsCollapseOpen(!isCollapseOpen),
+        onButtonClick: () => setClickAmount(clickAmount + 1),
         onLinkClick: () => setClickAmount(clickAmount + 1),
         onClose: () => setClickAmount(clickAmount + 1),
         initialClickAmount: clickAmount,
+        isCollapseOpen,
     });
 };

--- a/packages/ui-core/src/components/Notification/doc/Notification.example.mdx
+++ b/packages/ui-core/src/components/Notification/doc/Notification.example.mdx
@@ -420,7 +420,6 @@ export const DemoNotificationWrapper: React.FC<IDemoNotificationWrapperProps> = 
       shadowLevel="high"
       isColored={false}
       isCollapseOpened
-      buttonText="Подключить"
       shortText="Устанавливает только начальное состояние расхлопа"
    >
       Устанавливает только начальное состояние расхлопа. Управляется только по кнопке расхлопа.
@@ -435,7 +434,6 @@ export const DemoNotificationWrapper: React.FC<IDemoNotificationWrapperProps> = 
                shadowLevel="high"
                isColored={false}
                isCollapseOpened={isCollapseOpen}
-               buttonText="Подключить"
                shortText="Есть управление состоянием расхлопа извне"
                onCollapseButtonClick={onCollapseButtonClick}
             >

--- a/packages/ui-core/src/components/Notification/doc/Notification.example.mdx
+++ b/packages/ui-core/src/components/Notification/doc/Notification.example.mdx
@@ -484,6 +484,6 @@ export const DemoNotificationWrapper: React.FC<IDemoNotificationWrapperProps> = 
       shadowLevel="zero"
       hasCloseButton
    >
-     Если высота контента меньше высоты иконки, то они выравниваются по центру контентной области.
+     Центрирование по вертикали при небольшой высоте текста.
    </Notification>
 </Playground>

--- a/packages/ui-core/src/components/Notification/doc/Notification.example.mdx
+++ b/packages/ui-core/src/components/Notification/doc/Notification.example.mdx
@@ -1,27 +1,29 @@
 import { Playground, Props } from 'docz';
 import Notification from '../Notification';
 import { DemoNotificationWrapper, wrapperStyle } from './Notification.docz';
+import Button from 'components/Button/Button';
 import Rating1 from '@megafon/ui-icons/system-24-rating_1_24.svg';
 import Sended from '@megafon/ui-icons/system-16-sended_16.svg';
 import Cancel from '@megafon/ui-icons/system-16-cancel_16.svg';
 import Send from '@megafon/ui-icons/system-24-send_24.svg';
 
 ```javascript collapse=Код DemoNotificationWrapper
-export const DemoNotificationWrapper: React.FC<IDemoNotificationWrapperProps> = ( {
-    initialClickAmount = 0,
-    children,
-} ) => {
-    const [cliickAmount, setClickAmount] = useState(initialClickAmount);
+export const DemoNotificationWrapper: React.FC<IDemoNotificationWrapperProps> = ({
+   initialClickAmount = 0,
+   children,
+}) => {
+   const [clickAmount, setClickAmount] = useState(initialClickAmount);
+   const [isCollapseOpen, setIsCollapseOpen] = useState(true);
 
-    return (
-        <div>
-            {children({
-                onLinkClick: () => setClickAmount(cliickAmount + 1),
-                onClose: () => setClickAmount(cliickAmount + 1),
-                initialClickAmount: cliickAmount,
-            })}
-        </div>
-    );
+   return children({
+      onCollapseButtonClick: (value: boolean) => setIsCollapseOpen(value),
+      onWrapperButtonClick: () => setIsCollapseOpen(!isCollapseOpen),
+      onButtonClick: () => setClickAmount(clickAmount + 1),
+      onLinkClick: () => setClickAmount(clickAmount + 1),
+      onClose: () => setClickAmount(clickAmount + 1),
+      initialClickAmount: clickAmount,
+      isCollapseOpen,
+   });
 };
 ```
 
@@ -226,7 +228,7 @@ export const DemoNotificationWrapper: React.FC<IDemoNotificationWrapperProps> = 
 <Playground style={wrapperStyle}>
    <Notification
       type="info"
-      title="Для всех типов с белым фоном"
+      title="Для всех типов, кроме error с цветным фоном"
       shadowLevel="high"
       link="Cсылка синего цвета"
       target="_blank"
@@ -235,18 +237,10 @@ export const DemoNotificationWrapper: React.FC<IDemoNotificationWrapperProps> = 
    >
       Текст уведомления
    </Notification>
-   <Notification
-      type="warning"
-      title="Для типов info, success и warning, имеющих цветной фон"
-      link="Cсылка синего цвета"
-      href="/"
-      target="_blank"
-   >
-      Текст уведомления
-   </Notification>
+
    <Notification
       type="error"
-      title="Для типа error"
+      title="Для типа error с цветным фоном"
       link="Cсылка белого цвета"
       href="/"
       target="_blank"
@@ -312,6 +306,144 @@ export const DemoNotificationWrapper: React.FC<IDemoNotificationWrapperProps> = 
    />
 </Playground>
 
+## Уведомления с кнопками
+
+### Цвет кнопки меняется в зависимости от типа уведомления
+
+<Playground style={wrapperStyle}>
+   <Notification
+      type="info"
+      title="Для всех типов, кроме error с цветным фоном"
+      shadowLevel="high"
+      buttonText="Зеленая кнопка"
+      isColored={false}
+   >
+      Текст уведомления
+   </Notification>
+
+   <Notification
+      type="error"
+      title="Для типа error с цветным фоном"
+      buttonText="Белая кнопка"
+   >
+      Текст уведомления
+   </Notification>
+</Playground>
+
+### Комбинирование кнопки с расхлопом и ссылкой
+При недостаточной ширине элементы не переносятся в столбик, а всегда идут в одну строку. Текст на кнопке сокращается путем добавления в конце многоточия.
+
+<Playground style={wrapperStyle}>
+   <Notification
+      type="info"
+      title="Кнопка + ссылка"
+      shadowLevel="high"
+      buttonText="Кнопка"
+      link="Ссылка"
+      target="_blank"
+      href="/"
+      onButtonClick={() => {}}
+   >
+      Выравниваются по левому краю контента.
+   </Notification>
+
+   <Notification
+      type="warning"
+      title="Кнопка + расхлоп"
+      shadowLevel="high"
+      buttonText="Подключить"
+      shortText="Короткий текст уведомления"
+      isCollapseOpened
+      onButtonClick={() => {}}
+   >
+      Кнопка выравнивается по левому краю, расхлоп - по правому краю. 
+   </Notification>
+</Playground>
+
+### Кастомный обработчик клика по кнопке
+
+<Playground style={wrapperStyle}>
+   <DemoNotificationWrapper>
+      {({ initialClickAmount, onButtonClick }) =>
+         <Notification
+            type="info"
+            title="Заголовок уведомления"
+            shadowLevel="zero"
+            buttonText="Кнопка с обработчиком"
+            onButtonClick={onButtonClick}
+         >
+            {`Количество кликов: ${initialClickAmount}`}
+         </Notification>
+      }
+   </DemoNotificationWrapper>
+</Playground>
+
+## Уведомления с расхлопом
+   Расхлоп может комбинироваться с кнопкой, но не со ссылкой
+
+### По умолчанию
+
+<Playground style={wrapperStyle}>
+   <Notification
+      type="info"
+      title="По умолчанию расхлоп изначально закрыт"
+      shadowLevel="high"
+      shortText="Здание было красивым и странным: оно напоминало жилище эльфов"
+   >
+      Здание было красивым и странным: оно напоминало не то жилище эльфов, не то замок рыцарей-монахов. Белые шпили, стрельчатые окна, легкие мраморные беседки
+   </Notification>
+</Playground>
+
+### Кастомные заголовки расхлопа
+
+<Playground style={wrapperStyle}>
+   <Notification
+      type="success"
+      title="По умолчанию расхлоп изначально закрыт"
+      shadowLevel="high"
+      shortText="Здание было красивым и странным: оно напоминало жилище эльфов"
+      closeCollapseTitle="Показать весь текст"
+      openCollapseTitle=" Скрыть часть текста"
+   >
+      Здание было красивым и странным: оно напоминало не то жилище эльфов, не то замок рыцарей-монахов. Белые шпили, стрельчатые окна, легкие мраморные беседки
+   </Notification>
+</Playground>
+
+### Управление состоянием расхлопа
+
+<Playground style={wrapperStyle}>
+   <Notification
+      type="info"
+      title="Изначально открыт"
+      shadowLevel="high"
+      isColored={false}
+      isCollapseOpened
+      shortText="Устанавливает только начальное состояние расхлопа"
+   >
+      Устанавливает только начальное состояние расхлопа. Управляется только по кнопке расхлопа.
+   </Notification>
+
+   <DemoNotificationWrapper>
+      {({ isCollapseOpen, onWrapperButtonClick, onCollapseButtonClick }) =>
+         <div>
+            <Notification
+               type="info"
+               title="Изначально открыт"
+               shadowLevel="high"
+               isColored={false}
+               isCollapseOpened={isCollapseOpen}
+               shortText="Есть управление состоянием расхлопа извне"
+               onCollapseButtonClick={onCollapseButtonClick}
+            >
+               Есть управление состоянием расхлопа извне. Управлять состоянием расхлопа можно по внешней кнопке, либо по основной кнопке расхлопа.
+            </Notification>
+            <div style={{ marginTop: '15px' }}>
+               <Button onClick={onWrapperButtonClick}>Внешнее управление</Button>
+            </div>
+         </div>
+      }
+   </DemoNotificationWrapper>
+</Playground>
 
 ## Кнопка закрытия
 

--- a/packages/ui-core/src/components/Notification/doc/Notification.example.mdx
+++ b/packages/ui-core/src/components/Notification/doc/Notification.example.mdx
@@ -388,6 +388,7 @@ export const DemoNotificationWrapper: React.FC<IDemoNotificationWrapperProps> = 
       type="info"
       title="По умолчанию расхлоп изначально закрыт"
       shadowLevel="high"
+      buttonText="Подключить"
       shortText="Здание было красивым и странным: оно напоминало жилище эльфов"
    >
       Здание было красивым и странным: оно напоминало не то жилище эльфов, не то замок рыцарей-монахов. Белые шпили, стрельчатые окна, легкие мраморные беседки
@@ -401,6 +402,7 @@ export const DemoNotificationWrapper: React.FC<IDemoNotificationWrapperProps> = 
       type="success"
       title="По умолчанию расхлоп изначально закрыт"
       shadowLevel="high"
+      buttonText="Подключить"
       shortText="Здание было красивым и странным: оно напоминало жилище эльфов"
       closeCollapseTitle="Показать весь текст"
       openCollapseTitle=" Скрыть часть текста"
@@ -418,6 +420,7 @@ export const DemoNotificationWrapper: React.FC<IDemoNotificationWrapperProps> = 
       shadowLevel="high"
       isColored={false}
       isCollapseOpened
+      buttonText="Подключить"
       shortText="Устанавливает только начальное состояние расхлопа"
    >
       Устанавливает только начальное состояние расхлопа. Управляется только по кнопке расхлопа.
@@ -432,6 +435,7 @@ export const DemoNotificationWrapper: React.FC<IDemoNotificationWrapperProps> = 
                shadowLevel="high"
                isColored={false}
                isCollapseOpened={isCollapseOpen}
+               buttonText="Подключить"
                shortText="Есть управление состоянием расхлопа извне"
                onCollapseButtonClick={onCollapseButtonClick}
             >

--- a/src/gatsby-theme-docz/components/Layout/Layout.less
+++ b/src/gatsby-theme-docz/components/Layout/Layout.less
@@ -13,7 +13,7 @@
 
         width: 240px;
 
-        background: var(--base);
+        background: var(--background);
         transform: translateX(-240px);
 
         transition: transform 0.5s;
@@ -88,7 +88,7 @@
 
         color: var(--content);
 
-        background: var(--base);
+        background: var(--background);
 
         @media screen and (max-width: 1120px) {
             padding: 24px;

--- a/src/gatsby-theme-docz/index.less
+++ b/src/gatsby-theme-docz/index.less
@@ -14,5 +14,5 @@ body {
     margin: 0;
     padding: 0;
 
-    background-color: var(--base);
+    background-color: var(--background);
 }


### PR DESCRIPTION
<!-- Autogenerated checksum:eca7dfc6c6f0f7317f404b989bb8d7bd5ec429ed_a070d64fc0dfd28a4525ed249b9aaf4bcadcb69f -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "3.10.1"
"version": "3.11.0"

ui-shared/package.json
"version": "3.4.1"
"version": "3.4.2"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
# [3.11.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@3.10.1...@megafon/ui-core@3.11.0) (2022-06-16)


### Bug Fixes

* **button:** fix font styles for extra small size ([f475b05](https://github.com/MegafonWebLab/megafon-ui/commit/f475b05ab9d62aa56645fb90ccdef88996e72a70))


### Features

* **button:** add prop ellipsis ([1978277](https://github.com/MegafonWebLab/megafon-ui/commit/1978277a918cb680e32259042c1a7e3c58056b1b))
* **notification:** add ability to display button and collapse ([a5fe2f0](https://github.com/MegafonWebLab/megafon-ui/commit/a5fe2f0730b71469c2fb06a148b0e4574adb2d7b))





## :memo: packages/ui-shared/CHANGELOG.md
## [3.4.2](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.4.1...@megafon/ui-shared@3.4.2) (2022-06-16)

**Note:** Version bump only for package @megafon/ui-shared





