### PR TITLE
feat(switcher): add data-attribute for inner element

### DIFF
--- a/packages/ui-core/src/components/Switcher/Switcher.test.tsx
+++ b/packages/ui-core/src/components/Switcher/Switcher.test.tsx
@@ -11,7 +11,10 @@ describe('<Switcher />', () => {
 
         it('should render switcher with external className and data-attributes', () => {
             const wrapper = shallow(
-                <Switcher className="external-class-name" dataAttrs={{ root: { 'data-testid': 'root-test' } }} />,
+                <Switcher
+                    className="external-class-name"
+                    dataAttrs={{ root: { 'data-testid': 'root-test' }, input: { 'data-testid': 'input-test' } }}
+                />,
             );
             expect(wrapper).toMatchSnapshot();
         });

--- a/packages/ui-core/src/components/Switcher/Switcher.tsx
+++ b/packages/ui-core/src/components/Switcher/Switcher.tsx
@@ -13,6 +13,7 @@ export interface ISwitcherProps {
     /** Дополнительные data атрибуты к внутренним элементам */
     dataAttrs?: {
         root?: Record<string, string>;
+        input?: Record<string, string>;
     };
     /** Дополнительный класс корневого элемента */
     className?: string;
@@ -62,6 +63,7 @@ const Switcher: React.FC<ISwitcherProps> = ({
         <div className={cn({ disabled }, className)} {...filterDataAttrs(dataAttrs?.root)}>
             {isLeftContent && <div className={cn('content', { size: textSize, left: true })}>{children}</div>}
             <div
+                {...filterDataAttrs(dataAttrs?.input)}
                 className={cn('input', {
                     checked,
                     disabled,
@@ -83,6 +85,7 @@ const Switcher: React.FC<ISwitcherProps> = ({
 Switcher.propTypes = {
     dataAttrs: PropTypes.shape({
         root: PropTypes.objectOf(PropTypes.string.isRequired),
+        input: PropTypes.objectOf(PropTypes.string.isRequired),
     }),
     className: PropTypes.string,
     textSize: PropTypes.oneOf(['small', 'medium']),

--- a/packages/ui-core/src/components/Switcher/__snapshots__/Switcher.test.tsx.snap
+++ b/packages/ui-core/src/components/Switcher/__snapshots__/Switcher.test.tsx.snap
@@ -122,6 +122,7 @@ exports[`<Switcher /> layout should render switcher with external className and 
 >
   <div
     className="mfui-switcher__input mfui-switcher__input_no-touch"
+    data-testid="input-test"
     onClick={[Function]}
     onKeyDown={[Function]}
     tabIndex={0}


### PR DESCRIPTION
<!-- Autogenerated checksum:4afee2ab6a39e2713d8312d4b0fbc8b3a88a0570_793a0224ab957b938e67dd1b4d16c2389a9fb6f8 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "3.8.0"
"version": "3.9.0"

ui-shared/package.json
"version": "3.3.4"
"version": "3.3.5"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
# [3.9.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@3.8.0...@megafon/ui-core@3.9.0) (2022-05-26)


### Features

* **switcher:** add data-attribute for inner element ([793a022](https://github.com/MegafonWebLab/megafon-ui/commit/793a0224ab957b938e67dd1b4d16c2389a9fb6f8))





## :memo: packages/ui-shared/CHANGELOG.md
## [3.3.5](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.3.4...@megafon/ui-shared@3.3.5) (2022-05-26)

**Note:** Version bump only for package @megafon/ui-shared





