### PR TITLE
feat(text-with-icon): delete centering in mobile resolution

### DIFF
--- a/packages/ui-shared/src/components/TextWithIcon/TextWithIcon.less
+++ b/packages/ui-shared/src/components/TextWithIcon/TextWithIcon.less
@@ -5,9 +5,5 @@
 @{b} {
     &__header {
         margin-bottom: 24px;
-
-        @media @mobileSM {
-            text-align: center;
-        }
     }
 }

--- a/packages/ui-shared/src/components/TextWithIcon/TextWithIconItem.less
+++ b/packages/ui-shared/src/components/TextWithIcon/TextWithIconItem.less
@@ -6,10 +6,6 @@
     display: flex;
     align-items: center;
 
-    @media @mobileSM {
-        flex-direction: column;
-    }
-
     &:not(:first-of-type) {
         margin-top: 16px;
 
@@ -23,18 +19,7 @@
         min-width: 40px;
         height: 40px;
         min-height: 40px;
+        margin-right: 16px;
         overflow: hidden;
-
-        @media @mobileBU {
-            margin-right: 16px;
-        }
-    }
-
-    &__text {
-        @media @mobileSM {
-            margin-top: 12px;
-
-            text-align: center;
-        }
     }
 }


### PR DESCRIPTION
<!-- Autogenerated checksum:149af1811c79d7a7002c27479eb6388148ee0a89_1557a8cf334ad52143578daccd41c08c06d6254d -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-shared/package.json
"version": "4.0.0-beta.1"
"version": "4.0.0-beta.2"
```
### Changelogs:
## :memo: packages/ui-shared/CHANGELOG.md
# [4.0.0-beta.2](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@4.0.0-beta.1...@megafon/ui-shared@4.0.0-beta.2) (2022-05-30)


### Features

* **text-with-icon:** delete centering in mobile resolution ([1557a8c](https://github.com/MegafonWebLab/megafon-ui/commit/1557a8cf334ad52143578daccd41c08c06d6254d))


### BREAKING CHANGES

* **text-with-icon:** centering in mobile resolution was removed according guides





