### PR TITLE
refactor(notification): remove redundant state

### DIFF
--- a/packages/ui-core/src/components/Notification/Notification.tsx
+++ b/packages/ui-core/src/components/Notification/Notification.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { cnCreate, filterDataAttrs } from '@megafon/ui-helpers';
 import ErrorIcon from '@megafon/ui-icons/basic-24-block_24.svg';
 import ArrowDown from '@megafon/ui-icons/system-16-arrow-list_down_16.svg';
@@ -35,11 +35,6 @@ export const ShadowTypes = {
 
 type ShadowType = typeof ShadowTypes[keyof typeof ShadowTypes];
 
-type RefsType = {
-    fullText?: HTMLDivElement | null;
-    shortText?: HTMLDivElement | null;
-    textWrap?: HTMLDivElement | null;
-};
 export interface INotificationProps {
     /** Дополнительный класс корневого элемента */
     className?: string;
@@ -137,7 +132,6 @@ const Notification: React.FC<INotificationProps> = ({
 
     const [showFullText, setShowFullText] = useState(isCollapseOpened);
     const [updateTextHeight, setUpdateTextHeight] = useState(false);
-    const [refs, setRefs] = useState<RefsType>({});
 
     const initialTextClasses = {
         short: { hidden: shortText && showFullText },
@@ -153,45 +147,37 @@ const Notification: React.FC<INotificationProps> = ({
         setShowFullText(isCollapseOpened);
     }, [isCollapseOpened]);
 
-    useLayoutEffect(() => {
-        setRefs({
-            fullText: fullTextRef.current,
-            shortText: shortTextRef.current,
-            textWrap: wrapTextRef.current,
-        });
-    }, []);
-
     useEffect((): void => {
-        if (!refs.fullText || !refs.shortText || !refs.textWrap) {
+        if (!fullTextRef.current || !shortTextRef.current || !wrapTextRef.current) {
             return undefined;
         }
 
-        const visibleElement = showFullText ? refs.shortText : refs.fullText;
+        const visibleElement = showFullText ? shortTextRef.current : fullTextRef.current;
 
         const { height } = visibleElement.getBoundingClientRect();
 
-        refs.textWrap.style.height = `${height}px`;
+        wrapTextRef.current.style.height = `${height}px`;
 
         return setUpdateTextHeight(!updateTextHeight);
         // не должен запускаться при изменении флага updateTextHeight;
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [showFullText, refs]);
+    }, [showFullText]);
 
     useEffect(() => {
-        if (!refs.fullText || !refs.shortText || !refs.textWrap) {
+        if (!fullTextRef.current || !shortTextRef.current || !wrapTextRef.current) {
             return undefined;
         }
 
-        const hiddenElement = showFullText ? refs.fullText : refs.shortText;
+        const hiddenElement = showFullText ? fullTextRef.current : shortTextRef.current;
 
         const { height } = hiddenElement.getBoundingClientRect();
 
-        refs.textWrap.style.height = `${height}px`;
+        wrapTextRef.current.style.height = `${height}px`;
         setTextClass(initialTextClasses);
 
         const timeoutId = setTimeout(() => {
-            if (refs.textWrap) {
-                refs.textWrap.style.height = 'auto';
+            if (wrapTextRef.current) {
+                wrapTextRef.current.style.height = 'auto';
             }
         }, TIMEOUT_DELAY);
 


### PR DESCRIPTION
<!-- Autogenerated checksum:fa0612007b532cbc27bcc2f0f46312ca6693ada6_01ae454d30c6bb2e63a68da8b119b3269772aceb -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "3.10.1"
"version": "3.11.0"

ui-shared/package.json
"version": "3.4.1"
"version": "3.4.2"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
# [3.11.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@3.10.1...@megafon/ui-core@3.11.0) (2022-06-21)


### Bug Fixes

* **button:** fix font styles for extra small size ([f475b05](https://github.com/MegafonWebLab/megafon-ui/commit/f475b05ab9d62aa56645fb90ccdef88996e72a70))


### Features

* **button:** add prop ellipsis ([1978277](https://github.com/MegafonWebLab/megafon-ui/commit/1978277a918cb680e32259042c1a7e3c58056b1b))
* **notification:** add ability to display button and collapse ([a5fe2f0](https://github.com/MegafonWebLab/megafon-ui/commit/a5fe2f0730b71469c2fb06a148b0e4574adb2d7b))





## :memo: packages/ui-shared/CHANGELOG.md
## [3.4.2](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.4.1...@megafon/ui-shared@3.4.2) (2022-06-21)

**Note:** Version bump only for package @megafon/ui-shared





