### PR TITLE
feat(tab): add data-attribute for inner element

### DIFF
--- a/packages/ui-core/src/components/Tabs/Tab.tsx
+++ b/packages/ui-core/src/components/Tabs/Tab.tsx
@@ -12,6 +12,7 @@ export interface ITabProps {
     /** Дополнительные data атрибуты к внутренним элементам */
     dataAttrs?: {
         root?: Record<string, string>;
+        inner?: Record<string, string>;
     };
     /** Дочерние элементы */
     children?: React.ReactNode;
@@ -24,6 +25,7 @@ const Tab: React.FC<ITabProps> = ({ children }) => <>{children}</>;
 Tab.propTypes = {
     dataAttrs: PropTypes.shape({
         root: PropTypes.objectOf(PropTypes.string.isRequired),
+        inner: PropTypes.objectOf(PropTypes.string.isRequired),
     }),
     title: PropTypes.string,
     icon: PropTypes.node,

--- a/packages/ui-core/src/components/Tabs/Tabs.test.tsx
+++ b/packages/ui-core/src/components/Tabs/Tabs.test.tsx
@@ -63,7 +63,7 @@ describe('<Tabs />', () => {
                     title="title 1"
                     icon={<Balance />}
                     href="www.test.com"
-                    dataAttrs={{ root: { 'date-test': 'test' } }}
+                    dataAttrs={{ root: { 'data-testid': 'root' }, inner: { 'data-testid': 'inner' } }}
                 >
                     1
                 </Tab>

--- a/packages/ui-core/src/components/Tabs/Tabs.tsx
+++ b/packages/ui-core/src/components/Tabs/Tabs.tsx
@@ -243,7 +243,7 @@ const Tabs: React.FC<ITabsProps> = ({
     }, [outerObserveContainer]);
 
     const renderTab = React.useCallback(
-        (index: number, title?: string, icon?: React.ReactNode, href?: string) => {
+        (index: number, title?: string, icon?: React.ReactNode, href?: string, attr?: Record<string, string>) => {
             const ElementType = href ? 'a' : 'div';
 
             return (
@@ -253,6 +253,7 @@ const Tabs: React.FC<ITabsProps> = ({
                         current: currentIndex === index,
                     })}
                     onClick={handleTabInnerClick(index)}
+                    {...filterDataAttrs(attr, index + 1)}
                 >
                     {!!icon && <div className={cn('tab-icon')}>{icon}</div>}
                     {!!title && <div className={cn('tab-title')}>{title}</div>}
@@ -268,7 +269,7 @@ const Tabs: React.FC<ITabsProps> = ({
                 const {
                     props: { title, icon, href, renderTabWrapper, dataAttrs: data },
                 } = child;
-                const tab = renderTab(i, title, icon, href);
+                const tab = renderTab(i, title, icon, href, data?.inner);
 
                 const activeTabClassName = currentIndex === i ? activeTabClass : undefined;
 

--- a/packages/ui-core/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/ui-core/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -131,9 +131,11 @@ exports[`<Tabs /> should render with props 1`] = `
         >
           <div
             className="mfui-tabs__tab tabClass"
+            data-testid="root[1]"
           >
             <a
               className="mfui-tabs__tab-inner"
+              data-testid="inner[1]"
               href="www.test.com"
               onClick={[Function]}
             >


### PR DESCRIPTION
<!-- Autogenerated checksum:c0c35d6f50202e8af91b58ca10cf2b9cbb58a71d_43e58e12b8da661020f4b48f55245492c21ad376 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "3.11.0"
"version": "3.12.0"

ui-shared/package.json
"version": "3.4.2"
"version": "3.4.3"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
# [3.12.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@3.11.0...@megafon/ui-core@3.12.0) (2022-06-24)


### Features

* **tab:** add data-attribute for inner element ([43e58e1](https://github.com/MegafonWebLab/megafon-ui/commit/43e58e12b8da661020f4b48f55245492c21ad376))





## :memo: packages/ui-shared/CHANGELOG.md
## [3.4.3](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.4.2...@megafon/ui-shared@3.4.3) (2022-06-24)

**Note:** Version bump only for package @megafon/ui-shared





