### PR TITLE
chore: ui-core: update peerDependency of ui-icons to ^1.0.0

### DIFF
--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -43,7 +43,7 @@
     ]
   },
   "peerDependencies": {
-    "@megafon/ui-icons": "^0.0.2-beta.2",
+    "@megafon/ui-icons": "^1.0.0",
     "react": ">=16.13.0",
     "react-dom": ">=16.13.0"
   },


### PR DESCRIPTION
<!-- Autogenerated checksum:937a89d31be941889706301984fdbf6c1e1852b2_0b8f9861108fbbb8743a2a5d209647324dd45290 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "3.12.0"
"version": "3.12.1"

ui-shared/package.json
"version": "3.4.3"
"version": "3.4.4"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
## [3.12.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@3.12.0...@megafon/ui-core@3.12.1) (2022-07-05)

**Note:** Version bump only for package @megafon/ui-core





## :memo: packages/ui-shared/CHANGELOG.md
## [3.4.4](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.4.3...@megafon/ui-shared@3.4.4) (2022-07-05)

**Note:** Version bump only for package @megafon/ui-shared





