### PR TITLE
feat(videobanner): add buttonTarget and linkTarget props

### DIFF
--- a/packages/ui-shared/src/components/VideoBanner/VideoBanner.test.tsx
+++ b/packages/ui-shared/src/components/VideoBanner/VideoBanner.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { cnCreate } from '@megafon/ui-helpers';
 import { shallow, mount } from 'enzyme';
-import VideoBanner, { VideoType, ButtonColor, ClassName, TextColor } from './VideoBanner';
+import VideoBanner, { VideoType, ButtonColor, ClassName, TextColor, IContent } from './VideoBanner';
 
 const imageMobile = 'imageMobile';
 const imageTablet = 'imageTablet';
@@ -11,14 +11,16 @@ const imageDesktopWide = 'imageDesktopWide';
 const video = 'video.mp4';
 const youtubeVideoId = '2Sps5MnvlKM';
 
-const content = {
+const content: IContent = {
     title: 'Текст ≈40 симовлов. Короткие слова',
     description:
         'Описание должно быть примерно не более 130 символов. Пишите содержательно, кратно и не будет проблем с текстовым контентом.',
     buttonHref: '#',
+    buttonTarget: '_blank',
     buttonTitle: 'Текст в кнопке',
     linkTitle: 'Личный кабинет услуги',
     linkUrl: '#',
+    linkTarget: '_blank',
     cost: 'oт <b>1000 ₽</b> за сообщение',
 };
 

--- a/packages/ui-shared/src/components/VideoBanner/VideoBanner.tsx
+++ b/packages/ui-shared/src/components/VideoBanner/VideoBanner.tsx
@@ -56,6 +56,8 @@ export interface IContent {
     buttonTitle?: string;
     /** Ссылка на кнопке */
     buttonHref?: string;
+    /** Target свойство кнопки */
+    buttonTarget?: '_self' | '_blank' | '_parent' | '_top';
     /** Добавляет атрибут download для тега <a> компонента Button */
     buttonDownload?: boolean;
     /** Цвет кнопки */
@@ -72,6 +74,8 @@ export interface IContent {
     linkTitle?: string;
     /** Адрес ссылки */
     linkUrl?: string;
+    /** Target свойство ссылки */
+    linkTarget?: '_self' | '_blank' | '_parent' | '_top';
     /** Добавляет атрибут download для тега <a> компонента TextLink */
     linkDownload?: boolean;
     /** Строка со стоимостью услуги */
@@ -147,6 +151,7 @@ const VideoBanner: React.FC<IVideoBannerProps> = ({
             description,
             buttonTitle,
             buttonHref,
+            buttonTarget,
             buttonDownload,
             buttonColor = ButtonColor.GREEN,
             onButtonClick,
@@ -155,9 +160,10 @@ const VideoBanner: React.FC<IVideoBannerProps> = ({
             textColorMobile,
             linkTitle,
             linkUrl,
+            linkTarget,
             linkDownload,
             cost,
-        }) => (
+        }: IContent) => (
             <Grid className={cn('grid')} guttersLeft="medium">
                 <GridColumn mobile="12" tablet="7" desktop="7" wide="6">
                     <div
@@ -182,6 +188,7 @@ const VideoBanner: React.FC<IVideoBannerProps> = ({
                                     className={cn(ClassName.BUTTON, [classes.button])}
                                     theme={buttonColor}
                                     href={buttonHref}
+                                    target={buttonTarget}
                                     onClick={onButtonClick}
                                     download={buttonDownload}
                                 >
@@ -194,6 +201,7 @@ const VideoBanner: React.FC<IVideoBannerProps> = ({
                                     className={cn(ClassName.LINK, [classes.link])}
                                     href={linkUrl}
                                     download={linkDownload}
+                                    target={linkTarget}
                                     onClick={onLinkClick}
                                 >
                                     {linkTitle}

--- a/packages/ui-shared/src/components/VideoBanner/__snapshots__/VideoBanner.test.tsx.snap
+++ b/packages/ui-shared/src/components/VideoBanner/__snapshots__/VideoBanner.test.tsx.snap
@@ -91,6 +91,7 @@ exports[`<VideoBanner /> render component with breadcrumbs 1`] = `
                   }
                 }
                 href="#"
+                target="_blank"
                 theme="green"
               >
                 Текст в кнопке
@@ -103,6 +104,7 @@ exports[`<VideoBanner /> render component with breadcrumbs 1`] = `
                   }
                 }
                 href="#"
+                target="_blank"
               >
                 Личный кабинет услуги
               </TextLink>
@@ -195,6 +197,7 @@ exports[`<VideoBanner /> render component with classes 1`] = `
                   }
                 }
                 href="#"
+                target="_blank"
                 theme="green"
               >
                 Текст в кнопке
@@ -207,6 +210,7 @@ exports[`<VideoBanner /> render component with classes 1`] = `
                   }
                 }
                 href="#"
+                target="_blank"
               >
                 Личный кабинет услуги
               </TextLink>
@@ -332,6 +336,7 @@ exports[`<VideoBanner /> render component with non default buttonColor 1`] = `
                   }
                 }
                 href="#"
+                target="_blank"
                 theme="purple"
               >
                 Текст в кнопке
@@ -344,6 +349,7 @@ exports[`<VideoBanner /> render component with non default buttonColor 1`] = `
                   }
                 }
                 href="#"
+                target="_blank"
               >
                 Личный кабинет услуги
               </TextLink>
@@ -468,6 +474,7 @@ exports[`<VideoBanner /> render component with pictures and content 1`] = `
                   }
                 }
                 href="#"
+                target="_blank"
                 theme="green"
               >
                 Текст в кнопке
@@ -480,6 +487,7 @@ exports[`<VideoBanner /> render component with pictures and content 1`] = `
                   }
                 }
                 href="#"
+                target="_blank"
               >
                 Личный кабинет услуги
               </TextLink>
@@ -573,6 +581,7 @@ exports[`<VideoBanner /> render component with pictures and download links conte
                 }
                 download={true}
                 href="#"
+                target="_blank"
                 theme="green"
               >
                 Текст в кнопке
@@ -586,6 +595,7 @@ exports[`<VideoBanner /> render component with pictures and download links conte
                 }
                 download={true}
                 href="#"
+                target="_blank"
               >
                 Личный кабинет услуги
               </TextLink>
@@ -678,6 +688,7 @@ exports[`<VideoBanner /> render component with pictures and non default content 
                   }
                 }
                 href="#"
+                target="_blank"
                 theme="green"
               >
                 Текст в кнопке
@@ -690,6 +701,7 @@ exports[`<VideoBanner /> render component with pictures and non default content 
                   }
                 }
                 href="#"
+                target="_blank"
               >
                 Личный кабинет услуги
               </TextLink>
@@ -782,6 +794,7 @@ exports[`<VideoBanner /> render component with the different content text color 
                   }
                 }
                 href="#"
+                target="_blank"
                 theme="green"
               >
                 Текст в кнопке
@@ -794,6 +807,7 @@ exports[`<VideoBanner /> render component with the different content text color 
                   }
                 }
                 href="#"
+                target="_blank"
               >
                 Личный кабинет услуги
               </TextLink>
@@ -886,6 +900,7 @@ exports[`<VideoBanner /> render component without button 1`] = `
                   }
                 }
                 href="#"
+                target="_blank"
               >
                 Личный кабинет услуги
               </TextLink>
@@ -927,9 +942,11 @@ exports[`<VideoBanner /> tests with local window render component with classes f
   content={
     Object {
       "buttonHref": "#",
+      "buttonTarget": "_blank",
       "buttonTitle": "Текст в кнопке",
       "cost": "oт <b>1000 ₽</b> за сообщение",
       "description": "Описание должно быть примерно не более 130 символов. Пишите содержательно, кратно и не будет проблем с текстовым контентом.",
+      "linkTarget": "_blank",
       "linkTitle": "Личный кабинет услуги",
       "linkUrl": "#",
       "title": "Текст ≈40 симовлов. Короткие слова",
@@ -1035,6 +1052,7 @@ exports[`<VideoBanner /> tests with local window render component with classes f
                               }
                             }
                             href="#"
+                            target="_blank"
                             theme="green"
                           >
                             <a
@@ -1042,6 +1060,8 @@ exports[`<VideoBanner /> tests with local window render component with classes f
                               disabled={false}
                               href="#"
                               onClick={[Function]}
+                              rel="noreferrer noopener"
+                              target="_blank"
                             >
                               <div
                                 className="mfui-button__inner"
@@ -1066,6 +1086,7 @@ exports[`<VideoBanner /> tests with local window render component with classes f
                               }
                             }
                             href="#"
+                            target="_blank"
                           >
                             <Link
                               className="mfui-text-link mfui-text-link_underline-visibility_hover mfui-text-link_underline-style_solid mfui-text-link_color_blue mfui-video-banner__link"
@@ -1075,10 +1096,12 @@ exports[`<VideoBanner /> tests with local window render component with classes f
                                 }
                               }
                               href="#"
+                              target="_blank"
                             >
                               <a
                                 className="mfui-text-link mfui-text-link_underline-visibility_hover mfui-text-link_underline-style_solid mfui-text-link_color_blue mfui-video-banner__link"
                                 href="#"
+                                target="_blank"
                               >
                                 Личный кабинет услуги
                               </a>
@@ -1382,9 +1405,11 @@ exports[`<VideoBanner /> tests with local window render with video and content 1
   content={
     Object {
       "buttonHref": "#",
+      "buttonTarget": "_blank",
       "buttonTitle": "Текст в кнопке",
       "cost": "oт <b>1000 ₽</b> за сообщение",
       "description": "Описание должно быть примерно не более 130 символов. Пишите содержательно, кратно и не будет проблем с текстовым контентом.",
+      "linkTarget": "_blank",
       "linkTitle": "Личный кабинет услуги",
       "linkUrl": "#",
       "title": "Текст ≈40 симовлов. Короткие слова",
@@ -1490,6 +1515,7 @@ exports[`<VideoBanner /> tests with local window render with video and content 1
                               }
                             }
                             href="#"
+                            target="_blank"
                             theme="green"
                           >
                             <a
@@ -1497,6 +1523,8 @@ exports[`<VideoBanner /> tests with local window render with video and content 1
                               disabled={false}
                               href="#"
                               onClick={[Function]}
+                              rel="noreferrer noopener"
+                              target="_blank"
                             >
                               <div
                                 className="mfui-button__inner"
@@ -1521,6 +1549,7 @@ exports[`<VideoBanner /> tests with local window render with video and content 1
                               }
                             }
                             href="#"
+                            target="_blank"
                           >
                             <Link
                               className="mfui-text-link mfui-text-link_underline-visibility_hover mfui-text-link_underline-style_solid mfui-text-link_color_blue mfui-video-banner__link"
@@ -1530,10 +1559,12 @@ exports[`<VideoBanner /> tests with local window render with video and content 1
                                 }
                               }
                               href="#"
+                              target="_blank"
                             >
                               <a
                                 className="mfui-text-link mfui-text-link_underline-visibility_hover mfui-text-link_underline-style_solid mfui-text-link_color_blue mfui-video-banner__link"
                                 href="#"
+                                target="_blank"
                               >
                                 Личный кабинет услуги
                               </a>

--- a/packages/ui-shared/src/components/VideoBanner/doc/VideoBanner.props.mdx
+++ b/packages/ui-shared/src/components/VideoBanner/doc/VideoBanner.props.mdx
@@ -14,18 +14,28 @@ interface IContent {
     buttonTitle?: string;
     /** Ссылка на кнопке */
     buttonHref?: string;
+    /** Target свойство кнопки */
+    buttonTarget?: '_self' | '_blank' | '_parent' | '_top';
+    /** Добавляет атрибут download для тега <a> компонента Button */
+    buttonDownload?: boolean;
     /** Цвет кнопки */
-    buttonColor?: 'green' | 'purple';
+    buttonColor?: ButtonColorType;
     /** Обработчик клика по кнопке */
     onButtonClick?: (e: React.SyntheticEvent<EventTarget>) => void;
+    /** Обработчик клика по ссылке */
+    onLinkClick?: (e: React.SyntheticEvent<EventTarget>) => void;
     /** Цвет текста */
-    textColor?: 'black' | 'white';
+    textColor?: TextColorType;
     /** Цвет текста на мобильном разрешении */
-    textColorMobile?: 'black' | 'white';
+    textColorMobile?: TextColorType;
     /** Текст ссылки */
     linkTitle?: string;
     /** Адрес ссылки */
     linkUrl?: string;
+    /** Target свойство ссылки */
+    linkTarget?: '_self' | '_blank' | '_parent' | '_top';
+    /** Добавляет атрибут download для тега <a> компонента TextLink */
+    linkDownload?: boolean;
     /** Строка со стоимостью услуги */
     cost?: string;
 }


### PR DESCRIPTION
<!-- Autogenerated checksum:24435bfc98f949ea9e2d60a415d4e90554cb1166_96dcfbc4ecffeb9fca9e9e15d2a5434e1b978481 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-shared/package.json
"version": "3.4.6"
"version": "3.5.0"
```
### Changelogs:
## :memo: packages/ui-shared/CHANGELOG.md
# [3.5.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@3.4.6...@megafon/ui-shared@3.5.0) (2022-09-07)


### Features

* **videobanner:** add buttonTarget and linkTarget props ([96dcfbc](https://github.com/MegafonWebLab/megafon-ui/commit/96dcfbc4ecffeb9fca9e9e15d2a5434e1b978481))





