### PR TITLE
feat(videobanner): allow using html tag in title and description of videobanner

### DIFF
--- a/packages/ui-shared/src/components/VideoBanner/VideoBanner.tsx
+++ b/packages/ui-shared/src/components/VideoBanner/VideoBanner.tsx
@@ -26,6 +26,24 @@ const typographyConfig = {
     },
 };
 
+const textConfig = {
+    ...typographyConfig,
+    br: {
+        component: () => (<br />) as JSX.Element,
+    },
+    '&nbsp': {
+        component: () => (<>String.fromCharCode(160)</>) as JSX.Element,
+    },
+    a: {
+        component: ({ href, children }) => <a href={href}>{children}</a>,
+        props: ['href'],
+    },
+    font: {
+        component: ({ color, children }) => <span style={{ color }}>{children}</span>,
+        props: ['color'],
+    },
+};
+
 export const VideoType = {
     YOUTUBE: 'youtube',
     VIDEO: 'video',
@@ -165,11 +183,11 @@ const VideoBanner: React.FC<IVideoBannerProps> = ({
                         })}
                     >
                         <Header className={cn('title')} as="h1" color="inherit">
-                            {title}
+                            {convert(title, textConfig)}
                         </Header>
                         <div className={cn('text')}>
                             <Header as="h5" color="inherit" className={cn('description')}>
-                                {description}
+                                {convert(description, textConfig)}
                             </Header>
                             {cost && <div className={cn('cost')}>{convert(cost, typographyConfig)}</div>}
                         </div>

--- a/packages/ui-shared/src/components/VideoBanner/doc/VideoBanner.docz.tsx
+++ b/packages/ui-shared/src/components/VideoBanner/doc/VideoBanner.docz.tsx
@@ -10,7 +10,7 @@ const youtubeVideoId = '2Sps5MnvlKM';
 const contentWithDefaultTextColor: IContent = {
     title: 'Текст ≈40 символов. Короткие слова',
     description:
-        'Описание должно быть примерно не более 130 символов. Пишите содержательно, кратно и не будет проблем с текстовым контентом.',
+        'Описание&nbspдолжно <a href="https://moscow.megafon.ru">быть</a> <font color="#CCCCCC">примерно</font> не более <b>130 символов</b>.<br>Пишите содержательно, кратно и не будет проблем с текстовым контентом.',
     buttonHref: '#',
     buttonTitle: 'Текст в кнопке',
     linkTitle: 'Личный кабинет услуги',

--- a/packages/ui-shared/src/components/VideoBanner/doc/VideoBanner.example.mdx
+++ b/packages/ui-shared/src/components/VideoBanner/doc/VideoBanner.example.mdx
@@ -55,6 +55,9 @@ const breadcrumbs = [
 Если в компоненте не указан источник видео, то необходимо добавить изображения для всех разрешений.
 <VideoBanner imageMobile='imageMobile' imageTablet='imageMobile' imageDesktop='imageDesktop' imageDesktopWide='imageDesktop' />
 
+В свойстве content в свойствах title и description поддерживаются некоторые HTML-теги: "<br>, <b>, <font color>, <a href>".
+Также поддерживается спецсимвол &nbsp.
+
 ```
 
 ## Базовое использование


### PR DESCRIPTION
List of allowed html-tag: "&lt;br&gt;, &nbsp, &lt;b&gt;, &lt;font color&gt;, &lt;a href&gt;"<!-- Autogenerated checksum:1429e7a01a2f0e9558a6f4085d6dd22170bc1ff7_31cf562b34f9d6eb30a43fccd1123fdc67393935 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-shared/package.json
"version": "4.0.3"
"version": "4.1.0"
```
### Changelogs:
## :memo: packages/ui-shared/CHANGELOG.md
# [4.1.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@4.0.3...@megafon/ui-shared@4.1.0) (2022-10-04)


### Features

* **videobanner:** allow using html tag: br, &nbsp, b, font color, a href in title and description ([31cf562](https://github.com/MegafonWebLab/megafon-ui/commit/31cf562b34f9d6eb30a43fccd1123fdc67393935))





