### PR TITLE
fix(textfield): fix input height in Safari

### DIFF
--- a/packages/ui-core/src/components/TextField/TextField.less
+++ b/packages/ui-core/src/components/TextField/TextField.less
@@ -24,6 +24,7 @@
     &__field {
         display: block;
         width: 100%;
+        margin: 0;
         padding: 25px 56px 9px 16px;
 
         border: 1px solid var(--spbSky2);


### PR DESCRIPTION
set margin to 0 for input in TextField which fixes component height in Safari<!-- Autogenerated checksum:d46a63dbfc20ee931c4e12a82287b7385596bbcf_b60e1acd76dc80b4609b55dc8256eb94e8e8ec0c -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "4.3.0"
"version": "4.3.1"

ui-shared/package.json
"version": "4.1.1"
"version": "4.1.2"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
## [4.3.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@4.3.0...@megafon/ui-core@4.3.1) (2022-10-06)


### Bug Fixes

* **textfield:** fix input height in Safari ([b60e1ac](https://github.com/MegafonWebLab/megafon-ui/commit/b60e1acd76dc80b4609b55dc8256eb94e8e8ec0c))





## :memo: packages/ui-shared/CHANGELOG.md
## [4.1.2](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@4.1.1...@megafon/ui-shared@4.1.2) (2022-10-06)

**Note:** Version bump only for package @megafon/ui-shared





