### PR TITLE
feat(card): add button onClick property

### DIFF
--- a/packages/ui-shared/src/components/Card/Card.test.tsx
+++ b/packages/ui-shared/src/components/Card/Card.test.tsx
@@ -51,6 +51,30 @@ describe('Card', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    it('render component with onClick for button', () => {
+        const wrapper = shallow(
+            <Card title={title} text={text} button={{ title: 'Click me', onClick: () => undefined }} />,
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('calls button onClick', () => {
+        const onClick = jest.fn();
+        const wrapper = mount(
+            <Card
+                title={title}
+                text={text}
+                button={{
+                    title: 'Click me',
+                    onClick,
+                }}
+            />,
+        );
+
+        wrapper.find('button').simulate('click');
+        expect(onClick).toBeCalled();
+    });
+
     it('render component with icon', () => {
         const wrapper = shallow(<Card title={title} text={text} svgSrc={svg} button={button} link={link} />);
         expect(wrapper).toMatchSnapshot();

--- a/packages/ui-shared/src/components/Card/Card.tsx
+++ b/packages/ui-shared/src/components/Card/Card.tsx
@@ -152,8 +152,8 @@ const Card: React.FC<ICard> = ({
             href: btnHref,
             title: btnTitle,
             target: btnTarget,
-            download: buttonDownload,
-            onClick: buttonOnClick,
+            download: btnDownload,
+            onClick: btnOnClick,
         } = button;
 
         return (
@@ -162,8 +162,8 @@ const Card: React.FC<ICard> = ({
                 className={cn('button', [classes.button])}
                 href={btnHref}
                 target={btnTarget}
-                download={buttonDownload}
-                onClick={buttonOnClick}
+                download={btnDownload}
+                onClick={btnOnClick}
             >
                 {btnTitle}
             </Button>
@@ -237,9 +237,10 @@ Card.propTypes = {
     text: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
     button: PropTypes.shape({
         title: PropTypes.string.isRequired,
-        href: PropTypes.string.isRequired,
+        href: PropTypes.string,
         target: PropTypes.oneOf(Object.values(Target)),
         download: PropTypes.bool,
+        onClick: PropTypes.func,
     }),
     link: PropTypes.shape({
         title: PropTypes.string.isRequired,

--- a/packages/ui-shared/src/components/Card/Card.tsx
+++ b/packages/ui-shared/src/components/Card/Card.tsx
@@ -13,9 +13,10 @@ type TargetType = typeof Target[keyof typeof Target];
 
 interface IButton {
     title: string;
-    href: string;
+    href?: string;
     target?: TargetType;
     download?: boolean;
+    onClick?: () => void;
 }
 
 interface ILink {
@@ -147,7 +148,13 @@ const Card: React.FC<ICard> = ({
             return null;
         }
 
-        const { href: btnHref, title: btnTitle, target: btnTarget, download: buttonDownload } = button;
+        const {
+            href: btnHref,
+            title: btnTitle,
+            target: btnTarget,
+            download: buttonDownload,
+            onClick: buttonOnClick,
+        } = button;
 
         return (
             <Button
@@ -156,6 +163,7 @@ const Card: React.FC<ICard> = ({
                 href={btnHref}
                 target={btnTarget}
                 download={buttonDownload}
+                onClick={buttonOnClick}
             >
                 {btnTitle}
             </Button>

--- a/packages/ui-shared/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/packages/ui-shared/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -271,6 +271,43 @@ exports[`Card render component with img, if image source and svg source are spec
 </div>
 `;
 
+exports[`Card render component with onClick for button 1`] = `
+<div
+  className="mfui-card"
+>
+  <div
+    className="mfui-card__inner"
+  >
+    <Header
+      as="h3"
+      className="mfui-card__title"
+    >
+      Смартфоны Huawei с дополнительной скидкой до 3000 ₽ и подарок — до 1000 ₽ на связь
+    </Header>
+    <div
+      className="mfui-card__text"
+    >
+      Сдайте старое оборудование в трейд‑ин и получите дополнительную скидку до 3000 ₽ на смартфоны Huawei и до 1000 ₽ на связь в подарок.
+    </div>
+    <div
+      className="mfui-card__btns-wrapper"
+    >
+      <Button
+        className="mfui-card__button"
+        dataAttrs={
+          Object {
+            "root": undefined,
+          }
+        }
+        onClick={[Function]}
+      >
+        Click me
+      </Button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Card render component with optional props 1`] = `
 <div
   className="mfui-card mfui-card_centered-text className rootClass"

--- a/packages/ui-shared/src/components/Card/doc/Card.docz.tsx
+++ b/packages/ui-shared/src/components/Card/doc/Card.docz.tsx
@@ -13,6 +13,12 @@ const button = {
     target: '_self',
 };
 
+const buttonWithClick = {
+    title: 'Подключить',
+    // eslint-disable-next-line no-alert
+    onClick: (): void => alert('Выполнено действие при клике на кнопку'),
+};
+
 const buttonWithLongTitle = {
     title: 'Очень длинный заголовок',
     href: '#',
@@ -30,4 +36,4 @@ const link = {
 
 const svg = <WiFi style={{ display: 'block', fill: '#00B956' }} />;
 
-export { title, text, button, link, fakeLink, img, imgShort, svg, buttonWithLongTitle };
+export { title, text, button, link, fakeLink, img, imgShort, svg, buttonWithClick, buttonWithLongTitle };

--- a/packages/ui-shared/src/components/Card/doc/Card.example.mdx
+++ b/packages/ui-shared/src/components/Card/doc/Card.example.mdx
@@ -1,7 +1,7 @@
 import { Playground } from 'docz';
 import Card from '../Card';
 import { Grid, GridColumn, Header } from '@megafon/ui-core';
-import { title, text, button, link, fakeLink, img, imgShort, svg, buttonWithLongTitle } from './Card.docz.tsx';
+import { title, text, button, link, fakeLink, img, imgShort, svg, buttonWithLongTitle, buttonWithClick } from './Card.docz.tsx';
 
 ```javascript collapse=Демо данные
 const title = 'Cмартфоны Huawei с дополнительной скидкой до 3000 ₽ и подарок — до 1000 ₽ на связь';
@@ -11,6 +11,12 @@ const button = {
     title: 'Подробнее',
     href: '#',
     target: '_self',
+};
+
+const buttonWithClick = {
+    title: 'Подключить',
+    // eslint-disable-next-line no-alert
+    onClick: (): void => alert('Выполнено действие при клике на кнопку'),
 };
 
 const buttonWithLongTitle = {
@@ -33,17 +39,29 @@ const img = './img.png';
 const svg = <WiFi style={{ display: 'block', fill: '#00B956' }} />;
 ```
 
+## Кнопка с обработчиком клика
+
+Если в проп `button` передать обработчик `onClick`, он будет вызван при клике на кнопку.
+
+<Playground>
+    <Grid guttersLeft="medium" guttersBottom="medium">
+        <GridColumn all="3" mobile="12">
+            <Card title={title} text={text} button={buttonWithClick} />
+        </GridColumn>
+    </Grid>
+</Playground>
+
 ## Изображение
 Если в карточке заданы изображение и иконка, то иконка будет проигнорирована.
 
 <Playground style={{ marginTop: '-50px' }}>
     <Grid guttersLeft="medium" guttersBottom="medium">
         <GridColumn all="3" mobile="12">
-            <Header as="h2" hAlign="center" margin>C картинкой</Header>
+            <Header as="h2" hAlign="center" margin>С картинкой</Header>
             <Card title={title} text={text} button={button} link={link} imageSrc={img} />
         </GridColumn>
         <GridColumn all="3" mobile="12">
-            <Header as="h2" hAlign="center" margin>C иконкой</Header>
+            <Header as="h2" hAlign="center" margin>С иконкой</Header>
             <Card title={title} text={text} button={button} link={link} svgSrc={svg} />
         </GridColumn>
         <GridColumn all="3" mobile="12">
@@ -69,8 +87,8 @@ const svg = <WiFi style={{ display: 'block', fill: '#00B956' }} />;
 </Playground>
 
 ## Кнопка и ссылка
-Если в компонент не добавлены кнопка и ссылка, то в параметрах самой карточки должна быть указана ссылка. 
-В таком случае карточка становится кликабельной и имеет hover состояние. 
+Если в компонент не добавлены кнопка и ссылка, то в параметрах самой карточки должна быть указана ссылка.
+В таком случае карточка становится кликабельной и имеет hover состояние.
 Чтобы обозначить такое поведение карточки, в неё можно добавить "ложную ссылку" (надпись синего цвета).
 
 <Playground style={{ marginTop: '-50px' }}>
@@ -95,7 +113,7 @@ const svg = <WiFi style={{ display: 'block', fill: '#00B956' }} />;
 </Playground>
 
 ### Позиционирование
-Позиционирование по левому краю применимо, если в карточке находится либо одна кнопка, либо одна ссылка. 
+Позиционирование по левому краю применимо, если в карточке находится либо одна кнопка, либо одна ссылка.
 Если в карточке находится и кнопка, и ссылка, то они располагаются всегда по центру.
 
 <Playground style={{ marginTop: '-50px' }}>

--- a/packages/ui-shared/src/components/Card/doc/Card.props.mdx
+++ b/packages/ui-shared/src/components/Card/doc/Card.props.mdx
@@ -17,6 +17,8 @@ interface IButton {
     href: string;
     /** Target свойство, аналогично свойству 'target' тега 'a' */
     target: TargetType;
+    /** Обработчик клика по кнопке */
+    onClick: () => void;
 }
 
 interface ILink {


### PR DESCRIPTION
- add for `button` prop `onClick` property
- make `button` prop `href` property optional<!-- Autogenerated checksum:ab68c8392f13f494977b7a6e44104f9ae1b1f64b_148ca04afb9194eff52421ca228dd4de5e094323 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-shared/package.json
"version": "4.1.2"
"version": "4.2.0"
```
### Changelogs:
## :memo: packages/ui-shared/CHANGELOG.md
# [4.2.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@4.1.2...@megafon/ui-shared@4.2.0) (2022-10-13)


### Bug Fixes

* **card:** add tests for button onClick; fix propTypes; ([148ca04](https://github.com/MegafonWebLab/megafon-ui/commit/148ca04afb9194eff52421ca228dd4de5e094323))


### Features

* **card:** add button onClick property ([766c66f](https://github.com/MegafonWebLab/megafon-ui/commit/766c66f609ee5a20b86322acd5a40dfc14cee223))





