### PR TITLE
Add minTextareaHeight and hideResizeButton props for textarea

### DIFF
--- a/packages/ui-core/src/components/TextField/TextField.test.tsx
+++ b/packages/ui-core/src/components/TextField/TextField.test.tsx
@@ -3,7 +3,7 @@ import { cnCreate, detectTouch } from '@megafon/ui-helpers';
 import Balance from '@megafon/ui-icons/basic-24-balance_24.svg';
 import { shallow, mount } from 'enzyme';
 import InputMask from 'react-input-mask';
-import TextField, { TextFieldProps, Verification } from './TextField';
+import TextField, { MinTextareaHeight, TextFieldProps, Verification } from './TextField';
 
 jest.mock('@megafon/ui-helpers', () => ({
     ...jest.requireActual('@megafon/ui-helpers'),
@@ -33,7 +33,7 @@ const commonProps = {
         input: 'inputClass',
     },
     className: 'customClass',
-    minTextareaHeight: 24 as const,
+    minTextareaHeight: MinTextareaHeight.ONE_ROW,
 };
 
 const dataAttrs: TextFieldProps['dataAttrs'] = {

--- a/packages/ui-core/src/components/TextField/TextField.test.tsx
+++ b/packages/ui-core/src/components/TextField/TextField.test.tsx
@@ -33,6 +33,7 @@ const commonProps = {
         input: 'inputClass',
     },
     className: 'customClass',
+    minTextareaHeight: 24 as const,
 };
 
 const dataAttrs: TextFieldProps['dataAttrs'] = {
@@ -359,6 +360,12 @@ describe('<TextField />', () => {
 
         it('should render flexible textarea', () => {
             const wrapper = shallow(<TextField {...commonProps} textarea="flexible" />);
+
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        it('should render flexible textarea without resize button', () => {
+            const wrapper = shallow(<TextField {...commonProps} textarea="flexible" hideResizeButton />);
 
             expect(wrapper).toMatchSnapshot();
         });

--- a/packages/ui-core/src/components/TextField/TextField.tsx
+++ b/packages/ui-core/src/components/TextField/TextField.tsx
@@ -34,6 +34,13 @@ export const TextareaTypes = {
     FLEXIBLE: 'flexible',
 } as const;
 
+export const MinTextareaHeight = {
+    ONE_ROW: ROW_HEIGHT,
+    THREE_ROWS: ROW_HEIGHT * 3,
+} as const;
+
+type MinTextareaHeightType = typeof MinTextareaHeight[keyof typeof MinTextareaHeight];
+
 interface IMaskSelection {
     start: number;
     end: number;
@@ -108,7 +115,7 @@ export type TextFieldProps = {
     /** Переводит компонент в контролируемое состояние */
     isControlled?: boolean;
     /** Минимальная высота textarea, px */
-    minTextareaHeight?: 24 | 72;
+    minTextareaHeight?: MinTextareaHeightType;
     /** Скрывает кнопку ресайза для textarea="flexible" */
     hideResizeButton?: boolean;
     /** Обработчик изменения значения */
@@ -143,7 +150,7 @@ const TextField: React.FC<TextFieldProps> = ({
     placeholder,
     required,
     isControlled = false,
-    minTextareaHeight = 72,
+    minTextareaHeight = MinTextareaHeight.THREE_ROWS,
     hideResizeButton = false,
     onBlur,
     onChange,

--- a/packages/ui-core/src/components/TextField/TextField.tsx
+++ b/packages/ui-core/src/components/TextField/TextField.tsx
@@ -12,6 +12,11 @@ import throttleTime from 'constants/throttleTime';
 import ResizeIcon from './i/textarea-resizer.svg';
 import './TextField.less';
 
+const TEXTAREA_MAX_HEIGHT = 144;
+const DEFAULT_LABEL_TOP_POSITION = 16;
+const DEFAULT_ROW_COUNT = 3;
+const ROW_HEIGHT = 24;
+
 const DEFAULT_PLACEHOLDERS = {
     email: 'E-mail',
     tel: 'Номер телефона',
@@ -102,6 +107,10 @@ export type TextFieldProps = {
     autoComplete?: string;
     /** Переводит компонент в контролируемое состояние */
     isControlled?: boolean;
+    /** Минимальная высота textarea, px */
+    minTextareaHeight?: 24 | 72;
+    /** Скрывает кнопку ресайза для textarea="flexible" */
+    hideResizeButton?: boolean;
     /** Обработчик изменения значения */
     onChange?: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
     /** Обработчик изменения значения маскированного инпута до обработки маской */
@@ -115,12 +124,6 @@ export type TextFieldProps = {
     /** Обработчик клика добавленной иконки */
     onCustomIconClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
 };
-
-const TEXTAREA_MIN_HEIGHT = 48;
-const TEXTAREA_MAX_HEIGHT = 144;
-const DEFAULT_LABEL_TOP_POSITION = 16;
-const DEFAULT_ROW_COUNT = 3;
-const ROW_HEIGHT = 24;
 
 const cn = cnCreate('mfui-text-field');
 const TextField: React.FC<TextFieldProps> = ({
@@ -140,6 +143,8 @@ const TextField: React.FC<TextFieldProps> = ({
     placeholder,
     required,
     isControlled = false,
+    minTextareaHeight = 72,
+    hideResizeButton = false,
     onBlur,
     onChange,
     onBeforeMaskChange,
@@ -159,7 +164,7 @@ const TextField: React.FC<TextFieldProps> = ({
 }) => {
     const [isPasswordHidden, setPasswordHidden] = useState<boolean>(true);
     const [inputValue, setInputValue] = useState<string | number | undefined>(value);
-    const [initialTextareaHeight, setInitialTextareaHeight] = useState(ROW_HEIGHT * DEFAULT_ROW_COUNT);
+    const [initialTextareaHeight, setInitialTextareaHeight] = useState<number>(minTextareaHeight);
     const [isMaxLimitExceeded, setIsMaxLimitExceeded] = useState(false);
     const [currentNoticeText, setCurrentNoticeText] = useState(noticeText);
     const [isTextareaResizeFocused, setIsTextareaResizeFocused] = useState(false);
@@ -227,7 +232,7 @@ const TextField: React.FC<TextFieldProps> = ({
                     (moveEvent as MouseEvent).clientY || (moveEvent as TouchEvent).touches[0].clientY;
                 const resizeHeight = originalHeight + (currentCoordinateY - originalCoordinateY);
 
-                const updatedHeight = resizeHeight < TEXTAREA_MIN_HEIGHT ? TEXTAREA_MIN_HEIGHT : resizeHeight;
+                const updatedHeight = resizeHeight < minTextareaHeight ? minTextareaHeight : resizeHeight;
 
                 setInitialTextareaHeight(updatedHeight);
                 setIsTextareaResized(true);
@@ -251,7 +256,7 @@ const TextField: React.FC<TextFieldProps> = ({
 
         resizerRef.current.addEventListener('mousedown', handleStartResize);
         resizerRef.current.addEventListener('touchstart', handleStartResize);
-    }, [textarea]);
+    }, [textarea, minTextareaHeight]);
 
     const togglePasswordHiding = useCallback(() => setPasswordHidden(prevPassState => !prevPassState), []);
 
@@ -264,9 +269,9 @@ const TextField: React.FC<TextFieldProps> = ({
             current: { scrollHeight },
         } = fieldNode;
 
-        const extraRowCount = Math.round((scrollHeight - 28 - TEXTAREA_MIN_HEIGHT) / ROW_HEIGHT);
+        const extraRowCount = Math.round((scrollHeight - 28 - minTextareaHeight) / ROW_HEIGHT);
         const newHeight =
-            extraRowCount <= DEFAULT_ROW_COUNT ? TEXTAREA_MIN_HEIGHT + ROW_HEIGHT * extraRowCount : TEXTAREA_MAX_HEIGHT;
+            extraRowCount <= DEFAULT_ROW_COUNT ? minTextareaHeight + ROW_HEIGHT * extraRowCount : TEXTAREA_MAX_HEIGHT;
 
         setInitialTextareaHeight(newHeight);
     };
@@ -500,7 +505,7 @@ const TextField: React.FC<TextFieldProps> = ({
         >
             <div className={cn('field-wrapper', { textarea: textarea && textareaType })}>
                 {renderField()}
-                {textareaType === TextareaTypes.FLEXIBLE && (
+                {textareaType === TextareaTypes.FLEXIBLE && !hideResizeButton && (
                     <div className={cn('resizer')} ref={resizerRef}>
                         <ResizeIcon />
                     </div>
@@ -548,6 +553,8 @@ TextField.propTypes = {
     maskChar: PropTypes.string,
     noticeText: PropTypes.string,
     className: PropTypes.string,
+    minTextareaHeight: PropTypes.oneOf([24, 72]),
+    hideResizeButton: PropTypes.bool,
     onChange: PropTypes.func,
     onBeforeMaskChange: PropTypes.func,
     onBlur: PropTypes.func,

--- a/packages/ui-core/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/ui-core/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -1094,7 +1094,7 @@ exports[`<TextField /> textarea should render fixed textarea 1`] = `
       required={true}
       style={
         Object {
-          "height": "72px",
+          "height": "24px",
         }
       }
       value=""
@@ -1142,7 +1142,7 @@ exports[`<TextField /> textarea should render flexible textarea 1`] = `
       required={true}
       style={
         Object {
-          "height": "72px",
+          "height": "24px",
         }
       }
       value=""
@@ -1177,6 +1177,54 @@ exports[`<TextField /> textarea should render flexible textarea 1`] = `
 </div>
 `;
 
+exports[`<TextField /> textarea should render flexible textarea without resize button 1`] = `
+<div
+  className="mfui-text-field mfui-text-field_theme_white customClass"
+>
+  <div
+    className="mfui-text-field__field-wrapper mfui-text-field__field-wrapper_textarea_flexible"
+  >
+    <textarea
+      className="mfui-text-field__field mfui-text-field__field_type_flexible mfui-text-field__field_textarea_flexible inputClass"
+      id="id"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onScroll={[Function]}
+      placeholder="Текст"
+      required={true}
+      style={
+        Object {
+          "height": "24px",
+        }
+      }
+      value=""
+    />
+    <label
+      className="mfui-text-field__label labelClass"
+      htmlFor="id"
+    >
+      label
+      <span
+        className="mfui-text-field__require-mark"
+      >
+        *
+      </span>
+    </label>
+  </div>
+  <div
+    className="mfui-text-field__field-bottom-wrapper mfui-text-field__field-bottom-wrapper_filled"
+  >
+    <div
+      className="mfui-text-field__notice-text mfui-text-field__notice-text_active"
+      onTransitionEnd={[Function]}
+    >
+      noticeText
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<TextField /> textarea should render with error because of max limit is exceeded 1`] = `
 <div
   className="mfui-text-field mfui-text-field_theme_white mfui-text-field_error customClass"
@@ -1195,7 +1243,7 @@ exports[`<TextField /> textarea should render with error because of max limit is
       required={true}
       style={
         Object {
-          "height": "72px",
+          "height": "24px",
         }
       }
       value="123456"

--- a/packages/ui-core/src/components/TextField/doc/TextField.example.mdx
+++ b/packages/ui-core/src/components/TextField/doc/TextField.example.mdx
@@ -145,6 +145,26 @@ export const DemoTextFieldWithBeforeMaskChangeValue = ({ children }) => {
     </DemoTextFieldWithControlledValue>
 </Playground>
 
+## Цветовые схемы
+
+<Playground>
+    <div style={{ display: 'flex', gap: '35px' }}>
+        <div style={{ flex: 1, padding: '10px' }}>
+            <TextField 
+                verification="valid"
+                noticeText="Тема для светлого фона (по умолчанию)"
+            />
+        </div>
+        <div style={{ flex: 1, padding: '10px', backgroundColor: '#00B956' }}>
+            <TextField
+                verification="valid"
+                noticeText="Светлая тема для цветного фона"
+                theme="white"
+            />
+        </div>
+    </div>
+</Playground>
+
 ```javascript collapse=Код DemoControlledTextField
 export const DemoTextFieldWithControlledValue = ({ children }) => {
     const [inputValue, setInputValue] = useState('');
@@ -174,6 +194,12 @@ export const DemoTextFieldWithControlledValue = ({ children }) => {
 
 <Playground style={wrapperDefaultWidthStyle}>
     <TextField name="name" textarea="flexible"/>
+</Playground>
+
+## Отключение возможности ручного ресайза для textarea с типом flexible
+
+<Playground style={wrapperDefaultWidthStyle}>
+    <TextField textarea="flexible" hideResizeButton />
 </Playground>
 
 ## Обязательное поле
@@ -225,6 +251,23 @@ export const DemoTextFieldWithControlledValue = ({ children }) => {
     <TextField symbolCounter={10} textarea value="Иванов Иван Иванович"/>
 </Playground>
 
+## Минимальная высота textarea равна одной строке
+По умолчанию минимальная высота равна трем строкам
+
+<Playground style={wrapperWideWidthStyle}>
+    <TextField
+        textarea
+        minTextareaHeight={24}
+        label="fixed"
+    />
+
+    <TextField
+        textarea="flexible"
+        minTextareaHeight={24}
+        label="flexible"
+    />
+</Playground>
+
 ## Поле отключено для редактирования
 
 <Playground style={wrapperDefaultWidthStyle}>
@@ -233,24 +276,4 @@ export const DemoTextFieldWithControlledValue = ({ children }) => {
         textarea
         value='disabled'
     />
-</Playground>
-
-## Цветовые схемы
-
-<Playground>
-    <div style={{ display: 'flex', gap: '35px' }}>
-        <div style={{ flex: 1, padding: '10px' }}>
-            <TextField 
-                verification="valid"
-                noticeText="Тема для светлого фона (по умолчанию)"
-            />
-        </div>
-        <div style={{ flex: 1, padding: '10px', backgroundColor: '#00B956' }}>
-            <TextField
-                verification="valid"
-                noticeText="Светлая тема для цветного фона"
-                theme="white"
-            />
-        </div>
-    </div>
 </Playground>


### PR DESCRIPTION
<!-- Autogenerated checksum:5bbe52acfc131f03673fbb8c18761cfcb5df357e_f77c12e212cd41200f44290a2bacb3b9804f07e9 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "4.4.0"
"version": "4.5.0"

ui-shared/package.json
"version": "4.2.0"
"version": "4.2.1"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
# [4.5.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@4.4.0...@megafon/ui-core@4.5.0) (2022-10-14)


### Features

* **textfield:** add minTextareaHeight and hideResizeButton props for textarea ([088d219](https://github.com/MegafonWebLab/megafon-ui/commit/088d21971b69233522bb5cf7d642cffbc2571ca4))





## :memo: packages/ui-shared/CHANGELOG.md
## [4.2.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@4.2.0...@megafon/ui-shared@4.2.1) (2022-10-14)

**Note:** Version bump only for package @megafon/ui-shared





