### PR TITLE
feat(videoblock): add prop contentPositionRight

### DIFF
--- a/packages/ui-shared/src/components/VideoBlock/VideoBlock.less
+++ b/packages/ui-shared/src/components/VideoBlock/VideoBlock.less
@@ -24,6 +24,13 @@
         }
     }
 
+    &__content_position-right {
+        @media @mobileBU {
+            margin: 0 0 0 20px;
+            padding: 0 0 0 20px;
+        }
+    }
+
     &__header {
         margin-bottom: 24px;
 
@@ -93,5 +100,13 @@
 
     &__grid {
         width: 100%;
+    }
+
+    &__content-column_position-right {
+        order: 2;
+    }
+
+    &__video-column_position-left {
+        order: 1;
     }
 }

--- a/packages/ui-shared/src/components/VideoBlock/VideoBlock.test.tsx
+++ b/packages/ui-shared/src/components/VideoBlock/VideoBlock.test.tsx
@@ -27,6 +27,11 @@ describe('<VideoBlock />', () => {
         expect(component).toMatchSnapshot();
     });
 
+    it('it renders VideoBlock with contentPositionRight', () => {
+        const component = shallow(<VideoBlock videoSrc="video.mp4" content={content} contentPositionRight />);
+        expect(component).toMatchSnapshot();
+    });
+
     it('it renders VideoBlock with content but without button', () => {
         const component = shallow(<VideoBlock videoSrc="video.mp4" content={contentWithoutButton} />);
         expect(component).toMatchSnapshot();

--- a/packages/ui-shared/src/components/VideoBlock/VideoBlock.tsx
+++ b/packages/ui-shared/src/components/VideoBlock/VideoBlock.tsx
@@ -52,6 +52,8 @@ export interface IVideoBlockProps {
     isMuted?: boolean;
     /** Автоматическое проигрывание видео */
     isAutoplay?: boolean;
+    /** Расположение контента справа от видео. Только для десктопа */
+    contentPositionRight?: boolean;
 }
 
 const cn = cnCreate('mfui-video-block');
@@ -65,6 +67,7 @@ const VideoBlock: React.FC<IVideoBlockProps> = ({
     videoSrc,
     isMuted = true,
     isAutoplay = false,
+    contentPositionRight = false,
 }) => {
     const renderVideo = React.useCallback(() => {
         switch (videoType) {
@@ -93,7 +96,11 @@ const VideoBlock: React.FC<IVideoBlockProps> = ({
 
     const renderContent = React.useCallback(
         ({ title, description, href, buttonDownload, buttonTitle, onButtonClick }: IContent) => (
-            <div className={cn('content')}>
+            <div
+                className={cn('content', {
+                    'position-right': contentPositionRight,
+                })}
+            >
                 <Header as="h2" className={cn('header')}>
                     {title}
                 </Header>
@@ -111,7 +118,7 @@ const VideoBlock: React.FC<IVideoBlockProps> = ({
                 )}
             </div>
         ),
-        [classes.button, classes.description, dataAttrs?.button],
+        [classes.button, classes.description, dataAttrs?.button, contentPositionRight],
     );
 
     const renderGridColumns = React.useCallback(() => {
@@ -120,20 +127,38 @@ const VideoBlock: React.FC<IVideoBlockProps> = ({
 
         if (content) {
             columns.push(
-                <GridColumn all="5" tablet="12" mobile="12" orderTablet="2" orderMobile="2" key="column-content">
+                <GridColumn
+                    all="5"
+                    tablet="12"
+                    mobile="12"
+                    orderTablet="2"
+                    orderMobile="2"
+                    key="column-content"
+                    className={cn('content-column', {
+                        'position-right': contentPositionRight,
+                    })}
+                >
                     {renderContent(content)}
                 </GridColumn>,
             );
         }
 
         columns.push(
-            <GridColumn all={columnWidth} tablet="12" mobile="12" key="column-video">
+            <GridColumn
+                all={columnWidth}
+                tablet="12"
+                mobile="12"
+                key="column-video"
+                className={cn('video-column', {
+                    'position-left': contentPositionRight,
+                })}
+            >
                 <div className={cn('video-wrapper', { 'with-content': !!content })}>{renderVideo()}</div>
             </GridColumn>,
         );
 
         return columns;
-    }, [renderContent, renderVideo, content]);
+    }, [renderContent, renderVideo, content, contentPositionRight]);
 
     return (
         <div {...filterDataAttrs(dataAttrs?.root)} className={cn([className, classes.root])} ref={rootRef}>
@@ -172,6 +197,7 @@ VideoBlock.propTypes = {
     videoSrc: PropTypes.string.isRequired,
     isMuted: PropTypes.bool,
     isAutoplay: PropTypes.bool,
+    contentPositionRight: PropTypes.bool,
 };
 
 export default VideoBlock;

--- a/packages/ui-shared/src/components/VideoBlock/__snapshots__/VideoBlock.test.tsx.snap
+++ b/packages/ui-shared/src/components/VideoBlock/__snapshots__/VideoBlock.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`<VideoBlock /> it renders VideoBlock with autoplay 1`] = `
   >
     <GridColumn
       all="10"
+      className="mfui-video-block__video-column"
       key="column-video"
       mobile="12"
       tablet="12"
@@ -45,6 +46,7 @@ exports[`<VideoBlock /> it renders VideoBlock with classes 1`] = `
   >
     <GridColumn
       all="5"
+      className="mfui-video-block__content-column"
       key="column-content"
       mobile="12"
       orderMobile="2"
@@ -80,6 +82,7 @@ exports[`<VideoBlock /> it renders VideoBlock with classes 1`] = `
     </GridColumn>
     <GridColumn
       all="7"
+      className="mfui-video-block__video-column"
       key="column-video"
       mobile="12"
       tablet="12"
@@ -115,6 +118,7 @@ exports[`<VideoBlock /> it renders VideoBlock with content 1`] = `
   >
     <GridColumn
       all="5"
+      className="mfui-video-block__content-column"
       key="column-content"
       mobile="12"
       orderMobile="2"
@@ -150,6 +154,7 @@ exports[`<VideoBlock /> it renders VideoBlock with content 1`] = `
     </GridColumn>
     <GridColumn
       all="7"
+      className="mfui-video-block__video-column"
       key="column-video"
       mobile="12"
       tablet="12"
@@ -185,6 +190,7 @@ exports[`<VideoBlock /> it renders VideoBlock with content and button download l
   >
     <GridColumn
       all="5"
+      className="mfui-video-block__content-column"
       key="column-content"
       mobile="12"
       orderMobile="2"
@@ -221,6 +227,7 @@ exports[`<VideoBlock /> it renders VideoBlock with content and button download l
     </GridColumn>
     <GridColumn
       all="7"
+      className="mfui-video-block__video-column"
       key="column-video"
       mobile="12"
       tablet="12"
@@ -256,6 +263,7 @@ exports[`<VideoBlock /> it renders VideoBlock with content but without button 1`
   >
     <GridColumn
       all="5"
+      className="mfui-video-block__content-column"
       key="column-content"
       mobile="12"
       orderMobile="2"
@@ -280,6 +288,79 @@ exports[`<VideoBlock /> it renders VideoBlock with content but without button 1`
     </GridColumn>
     <GridColumn
       all="7"
+      className="mfui-video-block__video-column"
+      key="column-video"
+      mobile="12"
+      tablet="12"
+    >
+      <div
+        className="mfui-video-block__video-wrapper mfui-video-block__video-wrapper_with-content"
+      >
+        <video
+          autoPlay={false}
+          className="mfui-video-block__video"
+          controls={true}
+          loop={true}
+          muted={true}
+        >
+          <source
+            src="video.mp4"
+            type="video/mp4"
+          />
+        </video>
+      </div>
+    </GridColumn>
+  </Grid>
+</div>
+`;
+
+exports[`<VideoBlock /> it renders VideoBlock with contentPositionRight 1`] = `
+<div
+  className="mfui-video-block"
+>
+  <Grid
+    className="mfui-video-block__grid"
+    hAlign="center"
+  >
+    <GridColumn
+      all="5"
+      className="mfui-video-block__content-column mfui-video-block__content-column_position-right"
+      key="column-content"
+      mobile="12"
+      orderMobile="2"
+      orderTablet="2"
+      tablet="12"
+    >
+      <div
+        className="mfui-video-block__content mfui-video-block__content_position-right"
+      >
+        <Header
+          as="h2"
+          className="mfui-video-block__header"
+        >
+          Test title
+        </Header>
+        <div
+          className="mfui-video-block__description"
+        >
+          Test description
+        </div>
+        <Button
+          className="mfui-video-block__button"
+          dataAttrs={
+            Object {
+              "root": undefined,
+            }
+          }
+          href="#"
+        >
+          Button title
+        </Button>
+      </div>
+    </GridColumn>
+    <GridColumn
+      all="7"
+      className="mfui-video-block__video-column mfui-video-block__video-column_position-left"
       key="column-video"
       mobile="12"
       tablet="12"
@@ -316,6 +397,7 @@ exports[`<VideoBlock /> it renders VideoBlock with dataAttrs 1`] = `
   >
     <GridColumn
       all="5"
+      className="mfui-video-block__content-column"
       key="column-content"
       mobile="12"
       orderMobile="2"
@@ -353,6 +435,7 @@ exports[`<VideoBlock /> it renders VideoBlock with dataAttrs 1`] = `
     </GridColumn>
     <GridColumn
       all="7"
+      className="mfui-video-block__video-column"
       key="column-video"
       mobile="12"
       tablet="12"
@@ -388,6 +471,7 @@ exports[`<VideoBlock /> it renders VideoBlock with default props 1`] = `
   >
     <GridColumn
       all="10"
+      className="mfui-video-block__video-column"
       key="column-video"
       mobile="12"
       tablet="12"
@@ -423,6 +507,7 @@ exports[`<VideoBlock /> it renders VideoBlock with sound turned on 1`] = `
   >
     <GridColumn
       all="10"
+      className="mfui-video-block__video-column"
       key="column-video"
       mobile="12"
       tablet="12"
@@ -458,6 +543,7 @@ exports[`<VideoBlock /> it renders VideoBlock with youtube media type 1`] = `
   >
     <GridColumn
       all="10"
+      className="mfui-video-block__video-column"
       key="column-video"
       mobile="12"
       tablet="12"
@@ -489,6 +575,7 @@ exports[`<VideoBlock /> it renders VideoBlock with youtube media type and autopl
   >
     <GridColumn
       all="10"
+      className="mfui-video-block__video-column"
       key="column-video"
       mobile="12"
       tablet="12"
@@ -520,6 +607,7 @@ exports[`<VideoBlock /> it renders VideoBlock with youtube media type and sound 
   >
     <GridColumn
       all="10"
+      className="mfui-video-block__video-column"
       key="column-video"
       mobile="12"
       tablet="12"

--- a/packages/ui-shared/src/components/VideoBlock/doc/VideoBlock.example.mdx
+++ b/packages/ui-shared/src/components/VideoBlock/doc/VideoBlock.example.mdx
@@ -37,6 +37,16 @@ const contentWithoutButton: IContent = {
     />
 </Playground>
 
+## Текст справа от видео (только для десктопа)
+
+<Playground>
+    <VideoBlock
+        content={content}
+        videoSrc={video}
+        contentPositionRight
+    />
+</Playground>
+
 ### Без кнопки
 
 <Playground>


### PR DESCRIPTION
add prop contentPositionRight to place content after video<!-- Autogenerated checksum:1767b434f1650a100aa2aca6f5c795f8b549a184_6f1e603c1cd3489a18a9ccf5da5e1e0785c4f0cf -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-shared/package.json
"version": "4.2.1"
"version": "4.3.0"
```
### Changelogs:
## :memo: packages/ui-shared/CHANGELOG.md
# [4.3.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@4.2.1...@megafon/ui-shared@4.3.0) (2022-10-21)


### Features

* **videoblock:** add prop contentPositionRight ([6f1e603](https://github.com/MegafonWebLab/megafon-ui/commit/6f1e603c1cd3489a18a9ccf5da5e1e0785c4f0cf))





