### PR TITLE
fix(accordionbox): add missing margin for group of components

### DIFF
--- a/packages/ui-shared/src/components/AccordionBox/AccordionBox.less
+++ b/packages/ui-shared/src/components/AccordionBox/AccordionBox.less
@@ -6,12 +6,10 @@
 
 @{b} {
     & + & {
-        @{accordion} {
-            border-top: none;
-        }
-    }
+        margin-top: 8px;
 
-    @{property}:first-child {
-        border-top: none;
+        @media @mobileBU {
+            margin-top: 12px;
+        }
     }
 }

--- a/packages/ui-shared/src/components/AccordionBox/doc/AccordionBox.example.mdx
+++ b/packages/ui-shared/src/components/AccordionBox/doc/AccordionBox.example.mdx
@@ -13,6 +13,23 @@ import { Paragraph } from '@megafon/ui-core';
     </AccordionBox>
 </Playground>
 
+## Несколько компонентов
+
+<Playground>
+    <AccordionBox title="Accordion title 1">
+        <Paragraph hasMargin={false}>
+            Lorem ipsum, dolor sit amet consectetur adipisicing elit. Odit dolore quam deserunt magni consequuntur veniam!
+            Enim doloremque error expedita nisi nobis architecto aliquid. Iste dolores cupiditate earum vero, at quis.
+        </Paragraph>
+    </AccordionBox>
+        <AccordionBox title="Accordion title 2">
+        <Paragraph hasMargin={false}>
+            Lorem ipsum, dolor sit amet consectetur adipisicing elit. Odit dolore quam deserunt magni consequuntur veniam!
+            Enim doloremque error expedita nisi nobis architecto aliquid. Iste dolores cupiditate earum vero, at quis.
+        </Paragraph>
+    </AccordionBox>
+</Playground>
+
 ## Без ограничения по ширине
 
 <Playground>


### PR DESCRIPTION
<!-- Autogenerated checksum:fd77e756d2591ad3489e94c585d40bfa05e40710_e20da9336f664b526671e5950d319e8ef4dbd946 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-shared/package.json
"version": "4.4.0"
"version": "4.4.1"
```
### Changelogs:
## :memo: packages/ui-shared/CHANGELOG.md
## [4.4.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@4.4.0...@megafon/ui-shared@4.4.1) (2022-11-03)


### Bug Fixes

* **accordionbox:** add missing margin for group of components ([e20da93](https://github.com/MegafonWebLab/megafon-ui/commit/e20da9336f664b526671e5950d319e8ef4dbd946))





