### PR TITLE
fix(textfield): fix right padding with hideIcon prop

### DIFF
--- a/packages/ui-core/src/components/TextField/TextField.less
+++ b/packages/ui-core/src/components/TextField/TextField.less
@@ -61,6 +61,10 @@
         will-change: height;
     }
 
+    &__field_no-icon {
+        padding-right: 16px;
+    }
+
     &__resizer {
         position: absolute;
         right: 0;

--- a/packages/ui-core/src/components/TextField/TextField.tsx
+++ b/packages/ui-core/src/components/TextField/TextField.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useCallback, useEffect, useState, useRef, useMemo } from 'react';
-import throttleTime from 'constants/throttleTime';
 import { cnCreate, filterDataAttrs } from '@megafon/ui-helpers';
 import Hide from '@megafon/ui-icons/basic-24-hide_24.svg';
 import Show from '@megafon/ui-icons/basic-24-show_24.svg';
@@ -9,6 +8,7 @@ import CheckedIcon from '@megafon/ui-icons/system-24-checked_24.svg';
 import throttle from 'lodash.throttle';
 import * as PropTypes from 'prop-types';
 import InputMask from 'react-input-mask';
+import throttleTime from '../../constants/throttleTime';
 import ResizeIcon from './i/textarea-resizer.svg';
 import './TextField.less';
 

--- a/packages/ui-core/src/components/TextField/TextField.tsx
+++ b/packages/ui-core/src/components/TextField/TextField.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useCallback, useEffect, useState, useRef, useMemo } from 'react';
+import throttleTime from 'constants/throttleTime';
 import { cnCreate, filterDataAttrs } from '@megafon/ui-helpers';
 import Hide from '@megafon/ui-icons/basic-24-hide_24.svg';
 import Show from '@megafon/ui-icons/basic-24-show_24.svg';
@@ -8,7 +9,6 @@ import CheckedIcon from '@megafon/ui-icons/system-24-checked_24.svg';
 import throttle from 'lodash.throttle';
 import * as PropTypes from 'prop-types';
 import InputMask from 'react-input-mask';
-import throttleTime from 'constants/throttleTime';
 import ResizeIcon from './i/textarea-resizer.svg';
 import './TextField.less';
 
@@ -371,7 +371,13 @@ const TextField: React.FC<TextFieldProps> = ({
 
     const inputParams = {
         ...commonParams,
-        className: cn('field', classes?.input),
+        className: cn(
+            'field',
+            {
+                'no-icon': hideIcon,
+            },
+            classes?.input,
+        ),
         type: isVisiblePassword ? 'text' : type,
         autoComplete,
     };

--- a/packages/ui-core/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/ui-core/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -990,7 +990,7 @@ exports[`<TextField /> should render with hidden icon 1`] = `
     className="mfui-text-field__field-wrapper"
   >
     <input
-      className="mfui-text-field__field inputClass"
+      className="mfui-text-field__field mfui-text-field__field_no-icon inputClass"
       id="id"
       onBlur={[Function]}
       onChange={[Function]}

--- a/packages/ui-core/src/components/TextField/doc/TextField.example.mdx
+++ b/packages/ui-core/src/components/TextField/doc/TextField.example.mdx
@@ -11,13 +11,23 @@ import CustomIcon from '@megafon/ui-icons/system-24-rating_5_24.svg';
 ## Поле для ввода пароля
 
 <Playground style={wrapperDefaultWidthStyle}>
-    <TextField name="name" type="password"/>
+    <TextField name="password" type="password"/>
 </Playground>
 
 ## Обязательное поле
 
 <Playground style={wrapperDefaultWidthStyle}>
-    <TextField name="name" required label="Телефон"/>
+    <TextField name="phone" required label="Телефон"/>
+</Playground>
+
+## C иконкой очистки значения и без неё
+
+<Playground style={wrapperDefaultWidthStyle}>
+    <TextField name="name" label="Имя" value="Константин"/>
+</Playground>
+
+<Playground style={wrapperDefaultWidthStyle}>
+    <TextField name="name" label="Имя" value="Константин" hideIcon/>
 </Playground>
 
 ## Отключено отображение плейсхолдера
@@ -54,9 +64,9 @@ import CustomIcon from '@megafon/ui-icons/system-24-rating_5_24.svg';
         <div>
             <DemoTextFieldWithBeforeMaskChangeValue>
                 {({ handleBeforeMaskChange }) =>
-                    <TextField 
-                        onBeforeMaskChange={handleBeforeMaskChange} 
-                        mask="+7 (999) 999-99-99" 
+                    <TextField
+                        onBeforeMaskChange={handleBeforeMaskChange}
+                        mask="+7 (999) 999-99-99"
                         maskchar="_"
                         label="С перехватом вводимого значения"
                         style={{ width: '350px' }}
@@ -150,7 +160,7 @@ export const DemoTextFieldWithBeforeMaskChangeValue = ({ children }) => {
 <Playground>
     <div style={{ display: 'flex', gap: '35px' }}>
         <div style={{ flex: 1, padding: '10px' }}>
-            <TextField 
+            <TextField
                 verification="valid"
                 noticeText="Тема для светлого фона (по умолчанию)"
             />


### PR DESCRIPTION
<!-- Autogenerated checksum:fd77e756d2591ad3489e94c585d40bfa05e40710_95155ad13ed41704a1ff152f4c15e17962309c68 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "4.6.0"
"version": "4.6.1"

ui-shared/package.json
"version": "4.4.0"
"version": "4.4.1"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
## [4.6.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@4.6.0...@megafon/ui-core@4.6.1) (2022-11-03)


### Bug Fixes

* **textfield:** fix right padding with hideIcon prop ([c2aeffd](https://github.com/MegafonWebLab/megafon-ui/commit/c2aeffd1e4c94c97aac23128b9f1ccff4ead9a81))





## :memo: packages/ui-shared/CHANGELOG.md
## [4.4.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@4.4.0...@megafon/ui-shared@4.4.1) (2022-11-03)

**Note:** Version bump only for package @megafon/ui-shared





