### PR TITLE
feat(videoblock): added for title and description render html tags

### DIFF
--- a/packages/ui-shared/src/components/VideoBlock/VideoBlock.test.tsx
+++ b/packages/ui-shared/src/components/VideoBlock/VideoBlock.test.tsx
@@ -99,7 +99,7 @@ describe('<VideoBlock />', () => {
             ...content,
             title: '<a href="https://moscow.megafon.ru">Текст</a><br><font color="#731982">≈40</font> символов.&nbspКороткие слова',
             description:
-                'Описание&nbspдолжно <a href="https://moscow.megafon.ru">быть</a> <font color="#731982">примерно</font> не более 130 символов.<br>Пишите содержательно, кратно и не будет проблем с текстовым контентом.',
+                'Описание&nbspдолжно <a href="https://moscow.megafon.ru">быть</a> <font color="#731982">примерно</font> не более 130 символов.<br>Пишите <b>содержательно</b>, кратно и не будет проблем с текстовым контентом.',
         };
         const wrapper = shallow(<VideoBlock content={localContent} videoSrc="video" />);
 

--- a/packages/ui-shared/src/components/VideoBlock/VideoBlock.test.tsx
+++ b/packages/ui-shared/src/components/VideoBlock/VideoBlock.test.tsx
@@ -94,6 +94,18 @@ describe('<VideoBlock />', () => {
         expect(component).toMatchSnapshot();
     });
 
+    it('render component with html tags', () => {
+        const localContent = {
+            ...content,
+            title: '<a href="https://moscow.megafon.ru">Текст</a><br><font color="#731982">≈40</font> символов.&nbspКороткие слова',
+            description:
+                'Описание&nbspдолжно <a href="https://moscow.megafon.ru">быть</a> <font color="#731982">примерно</font> не более 130 символов.<br>Пишите содержательно, кратно и не будет проблем с текстовым контентом.',
+        };
+        const wrapper = shallow(<VideoBlock content={localContent} videoSrc="video" />);
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
     it('should return reference to root element', () => {
         const ref: React.RefObject<HTMLDivElement> = React.createRef();
 

--- a/packages/ui-shared/src/components/VideoBlock/VideoBlock.tsx
+++ b/packages/ui-shared/src/components/VideoBlock/VideoBlock.tsx
@@ -105,7 +105,7 @@ const VideoBlock: React.FC<IVideoBlockProps> = ({
                     {convert(title, titleConvertConfig)}
                 </Header>
                 <div className={cn('description', [classes.description])}>
-                    {convert(String(description), textConvertConfig)}
+                    {typeof description === 'string' ? convert(description, textConvertConfig) : description}
                 </div>
                 {buttonTitle && (
                     <Button

--- a/packages/ui-shared/src/components/VideoBlock/VideoBlock.tsx
+++ b/packages/ui-shared/src/components/VideoBlock/VideoBlock.tsx
@@ -1,6 +1,6 @@
 import React, { Ref } from 'react';
 import { Header, Button, Grid, GridColumn } from '@megafon/ui-core';
-import { cnCreate, filterDataAttrs, convert, titleConvertConfig } from '@megafon/ui-helpers';
+import { cnCreate, filterDataAttrs, convert, titleConvertConfig, textConvertConfig } from '@megafon/ui-helpers';
 import PropTypes from 'prop-types';
 import './VideoBlock.less';
 
@@ -8,7 +8,7 @@ export interface IContent {
     /** Заголовок */
     title: string;
     /** Текст-описание */
-    description: string;
+    description: string | React.ReactNode[] | React.ReactNode;
     /** Текст кнопки */
     buttonTitle?: string;
     /** Добавляет атрибут download для тега <a> компонента Button */
@@ -105,7 +105,7 @@ const VideoBlock: React.FC<IVideoBlockProps> = ({
                     {convert(title, titleConvertConfig)}
                 </Header>
                 <div className={cn('description', [classes.description])}>
-                    {convert(description, titleConvertConfig)}
+                    {convert(String(description), textConvertConfig)}
                 </div>
                 {buttonTitle && (
                     <Button
@@ -188,7 +188,8 @@ VideoBlock.propTypes = {
     ]),
     content: PropTypes.shape({
         title: PropTypes.string.isRequired,
-        description: PropTypes.string.isRequired,
+        description: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.node), PropTypes.node])
+            .isRequired,
         href: PropTypes.string,
         buttonTitle: PropTypes.string,
         buttonDownload: PropTypes.bool,

--- a/packages/ui-shared/src/components/VideoBlock/VideoBlock.tsx
+++ b/packages/ui-shared/src/components/VideoBlock/VideoBlock.tsx
@@ -1,6 +1,6 @@
 import React, { Ref } from 'react';
 import { Header, Button, Grid, GridColumn } from '@megafon/ui-core';
-import { cnCreate, filterDataAttrs } from '@megafon/ui-helpers';
+import { cnCreate, filterDataAttrs, convert, titleConvertConfig } from '@megafon/ui-helpers';
 import PropTypes from 'prop-types';
 import './VideoBlock.less';
 
@@ -8,7 +8,7 @@ export interface IContent {
     /** Заголовок */
     title: string;
     /** Текст-описание */
-    description: string | React.ReactNode[] | React.ReactNode;
+    description: string;
     /** Текст кнопки */
     buttonTitle?: string;
     /** Добавляет атрибут download для тега <a> компонента Button */
@@ -102,9 +102,11 @@ const VideoBlock: React.FC<IVideoBlockProps> = ({
                 })}
             >
                 <Header as="h2" className={cn('header')}>
-                    {title}
+                    {convert(title, titleConvertConfig)}
                 </Header>
-                <div className={cn('description', [classes.description])}>{description}</div>
+                <div className={cn('description', [classes.description])}>
+                    {convert(description, titleConvertConfig)}
+                </div>
                 {buttonTitle && (
                     <Button
                         dataAttrs={{ root: dataAttrs?.button }}
@@ -186,8 +188,7 @@ VideoBlock.propTypes = {
     ]),
     content: PropTypes.shape({
         title: PropTypes.string.isRequired,
-        description: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.node), PropTypes.node])
-            .isRequired,
+        description: PropTypes.string.isRequired,
         href: PropTypes.string,
         buttonTitle: PropTypes.string,
         buttonDownload: PropTypes.bool,

--- a/packages/ui-shared/src/components/VideoBlock/__snapshots__/VideoBlock.test.tsx.snap
+++ b/packages/ui-shared/src/components/VideoBlock/__snapshots__/VideoBlock.test.tsx.snap
@@ -691,7 +691,13 @@ exports[`<VideoBlock /> render component with html tags 1`] = `
           <component
             key="5"
           />
-          Пишите содержательно, кратно и не будет проблем с текстовым контентом.
+          Пишите 
+          <component
+            key="7"
+          >
+            содержательно
+          </component>
+          , кратно и не будет проблем с текстовым контентом.
         </div>
         <Button
           className="mfui-video-block__button"

--- a/packages/ui-shared/src/components/VideoBlock/__snapshots__/VideoBlock.test.tsx.snap
+++ b/packages/ui-shared/src/components/VideoBlock/__snapshots__/VideoBlock.test.tsx.snap
@@ -628,3 +628,108 @@ exports[`<VideoBlock /> it renders VideoBlock with youtube media type and sound 
   </Grid>
 </div>
 `;
+
+exports[`<VideoBlock /> render component with html tags 1`] = `
+<div
+  className="mfui-video-block"
+>
+  <Grid
+    className="mfui-video-block__grid"
+    hAlign="center"
+  >
+    <GridColumn
+      all="5"
+      className="mfui-video-block__content-column"
+      key="column-content"
+      mobile="12"
+      orderMobile="2"
+      orderTablet="2"
+      tablet="12"
+    >
+      <div
+        className="mfui-video-block__content"
+      >
+        <Header
+          as="h2"
+          className="mfui-video-block__header"
+        >
+          <component
+            href="https://moscow.megafon.ru"
+            key="0"
+          >
+            Текст
+          </component>
+          <component
+            key="1"
+          />
+          <component
+            color="#731982"
+            key="2"
+          >
+            ≈40
+          </component>
+           символов. Короткие слова
+        </Header>
+        <div
+          className="mfui-video-block__description"
+        >
+          Описание должно 
+          <component
+            href="https://moscow.megafon.ru"
+            key="1"
+          >
+            быть
+          </component>
+           
+          <component
+            color="#731982"
+            key="3"
+          >
+            примерно
+          </component>
+           не более 130 символов.
+          <component
+            key="5"
+          />
+          Пишите содержательно, кратно и не будет проблем с текстовым контентом.
+        </div>
+        <Button
+          className="mfui-video-block__button"
+          dataAttrs={
+            Object {
+              "root": undefined,
+            }
+          }
+          href="#"
+        >
+          Button title
+        </Button>
+      </div>
+    </GridColumn>
+    <GridColumn
+      all="7"
+      className="mfui-video-block__video-column"
+      key="column-video"
+      mobile="12"
+      tablet="12"
+    >
+      <div
+        className="mfui-video-block__video-wrapper mfui-video-block__video-wrapper_with-content"
+      >
+        <video
+          autoPlay={false}
+          className="mfui-video-block__video"
+          controls={true}
+          loop={true}
+          muted={true}
+        >
+          <source
+            src="video"
+            type="video/mp4"
+          />
+        </video>
+      </div>
+    </GridColumn>
+  </Grid>
+</div>
+`;

--- a/packages/ui-shared/src/components/VideoBlock/doc/VideoBlock.example.mdx
+++ b/packages/ui-shared/src/components/VideoBlock/doc/VideoBlock.example.mdx
@@ -96,7 +96,7 @@ const htmlDescription = 'Описание&nbspдолжно <a href="https://mosc
     <VideoBlock
         content={{
             title: '<a href="https://moscow.megafon.ru">Текст</a><br><font color="#731982">≈40</font> символов.&nbspКороткие слова',
-            description: 'Описание&nbspдолжно <a href="https://moscow.megafon.ru">быть</a> <font color="#731982">примерно</font> не более 130 символов.<br>Пишите содержательно, кратно и не будет проблем с текстовым контентом.',
+            description: 'Описание&nbspдолжно <a href="https://moscow.megafon.ru">быть</a> <font color="#731982">примерно</font> не более 130 символов.<br>Пишите <b>содержательно</b>, кратно и не будет проблем с текстовым контентом.',
             href: '#',
             buttonTitle: 'Подключение',
         }}

--- a/packages/ui-shared/src/components/VideoBlock/doc/VideoBlock.example.mdx
+++ b/packages/ui-shared/src/components/VideoBlock/doc/VideoBlock.example.mdx
@@ -74,3 +74,33 @@ const contentWithoutButton: IContent = {
         videoType="youtube"
     />
 </Playground>
+
+## HTML-теги и спецсимволы
+
+```javascript
+
+В свойстве content в свойствах title и description поддерживаются некоторые HTML-теги: "<br>, <font color>, <a href>".
+
+Также в обоих свойствах поддерживается спецсимвол &nbsp.
+
+```
+
+```javascript collapse=Демо данные
+const htmlTitle: '<a href="https://moscow.megafon.ru">Текст</a><br><font color="#731982">≈40</font> символов.&nbspКороткие слова',
+const htmlDescription = 'Описание&nbspдолжно <a href="https://moscow.megafon.ru">быть</a> <font color="#731982">примерно</font> не более 130 символов.<br>Пишите содержательно, кратно и не будет проблем с текстовым контентом.';
+
+
+```
+
+<Playground>
+    <VideoBlock
+        content={{
+            title: '<a href="https://moscow.megafon.ru">Текст</a><br><font color="#731982">≈40</font> символов.&nbspКороткие слова',
+            description: 'Описание&nbspдолжно <a href="https://moscow.megafon.ru">быть</a> <font color="#731982">примерно</font> не более 130 символов.<br>Пишите содержательно, кратно и не будет проблем с текстовым контентом.',
+            href: '#',
+            buttonTitle: 'Подключение',
+        }}
+        videoSrc={youtubeVideoId}
+        videoType="youtube"
+    />
+</Playground>


### PR DESCRIPTION
<!-- Autogenerated checksum:fdf1dafa6641670aad13352093dbed25dd0523f3_6e7de853b8ff920f4b0de2ecfd3cdb8538bc727a -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-shared/package.json
"version": "4.4.1"
"version": "4.5.0"
```
### Changelogs:
## :memo: packages/ui-shared/CHANGELOG.md
# [4.5.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@4.4.1...@megafon/ui-shared@4.5.0) (2022-11-11)


### Features

* **videoblock:** added for title and description render html tags ([d0d2255](https://github.com/MegafonWebLab/megafon-ui/commit/d0d2255abb80e73058151967721a447c8ebc4028))
* **videoblock:** fixed and ddded tag b for description ([6e7de85](https://github.com/MegafonWebLab/megafon-ui/commit/6e7de853b8ff920f4b0de2ecfd3cdb8538bc727a))
* **videoblock:** return types and change config for description ([75f18e1](https://github.com/MegafonWebLab/megafon-ui/commit/75f18e10e6cb22779cceaf90f8a6e0e258a92612))





