### PR TITLE
fix(tabs): remove tab underline on hover

### DIFF
--- a/packages/ui-core/src/components/Tabs/Tabs.less
+++ b/packages/ui-core/src/components/Tabs/Tabs.less
@@ -180,6 +180,10 @@
 
             fill: var(--spbSky3);
         }
+
+        &:hover {
+            text-decoration: none;
+        }
     }
 
     &__tab-inner:not(&__tab-inner_current) {


### PR DESCRIPTION
<!-- Autogenerated checksum:3abf1c61512c52a9d322edb9fb6bede9da952c44_1c6cfbde1c66c71c99c42ae4a586f048688f3afb -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "4.8.1"
"version": "4.8.2"

ui-shared/package.json
"version": "4.5.1"
"version": "4.5.2"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
## [4.8.2](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@4.8.1...@megafon/ui-core@4.8.2) (2022-11-21)


### Bug Fixes

* **tabs:** remove tab underline on hover ([1c6cfbd](https://github.com/MegafonWebLab/megafon-ui/commit/1c6cfbde1c66c71c99c42ae4a586f048688f3afb))





## :memo: packages/ui-shared/CHANGELOG.md
## [4.5.2](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@4.5.1...@megafon/ui-shared@4.5.2) (2022-11-21)

**Note:** Version bump only for package @megafon/ui-shared





