### PR TITLE
feat(textwithiconitem): add render html and classes

### DIFF
--- a/packages/ui-shared/src/components/TextWithIcon/TextWithIconItem.test.tsx
+++ b/packages/ui-shared/src/components/TextWithIcon/TextWithIconItem.test.tsx
@@ -11,6 +11,18 @@ describe('<TextWithIconItem />', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    it('should render with HTML and classes', () => {
+        const wrapper = shallow(
+            <TextWithIconItem
+                text="First item <b>with strong text</b>"
+                icon={<Star style={{ fill: '#00B956' }} />}
+                className="test-class"
+                classes={{ icon: 'icon-class', text: 'text-class' }}
+            />,
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
     it('should return reference to root element', () => {
         const ref: React.RefObject<HTMLDivElement> = React.createRef();
         mount(<TextWithIconItem text="First item" icon={<Star style={{ fill: '#00B956' }} />} rootRef={ref} />);

--- a/packages/ui-shared/src/components/TextWithIcon/TextWithIconItem.tsx
+++ b/packages/ui-shared/src/components/TextWithIcon/TextWithIconItem.tsx
@@ -1,9 +1,14 @@
 import * as React from 'react';
-import { cnCreate, filterDataAttrs } from '@megafon/ui-helpers';
+import { cnCreate, convert, filterDataAttrs, textConvertConfig } from '@megafon/ui-helpers';
 import * as PropTypes from 'prop-types';
 import './TextWithIconItem.less';
 
 export interface ITextWithIconItem {
+    /** Дополнительные классы для корневого и внутренних элементов */
+    classes?: {
+        icon?: string;
+        text?: string;
+    };
     /** Текст */
     text: string | string[];
     /** Иконка */
@@ -23,22 +28,33 @@ export interface ITextWithIconItem {
 
 const cn = cnCreate('mfui-text-with-icon-item');
 const TextWithIconItem: React.FC<ITextWithIconItem> = ({
+    className,
+    classes = {},
     text,
     icon,
     rootRef,
     dataAttrs,
     centeringOnMobile = true,
-    className,
-}) => (
-    <div
-        className={cn({ 'centering-on-mobile': centeringOnMobile }, [className])}
-        ref={rootRef}
-        {...filterDataAttrs(dataAttrs?.root)}
-    >
-        <div className={cn('svg-icon')}>{icon}</div>
-        <div className={cn('text')}>{text}</div>
-    </div>
-);
+}) => {
+    const renderText = React.useMemo(() => {
+        if (Array.isArray(text)) {
+            return text.map(item => convert(item, textConvertConfig));
+        }
+
+        return convert(text, textConvertConfig);
+    }, [text]);
+
+    return (
+        <div
+            className={cn({ 'centering-on-mobile': centeringOnMobile }, [className])}
+            ref={rootRef}
+            {...filterDataAttrs(dataAttrs?.root)}
+        >
+            <div className={cn('svg-icon', [classes.icon])}>{icon}</div>
+            <div className={cn('text', [classes.text])}>{renderText}</div>
+        </div>
+    );
+};
 
 TextWithIconItem.propTypes = {
     text: PropTypes.oneOfType([PropTypes.string.isRequired, PropTypes.arrayOf(PropTypes.string.isRequired)]).isRequired,

--- a/packages/ui-shared/src/components/TextWithIcon/TextWithIconItem.tsx
+++ b/packages/ui-shared/src/components/TextWithIcon/TextWithIconItem.tsx
@@ -4,7 +4,7 @@ import * as PropTypes from 'prop-types';
 import './TextWithIconItem.less';
 
 export interface ITextWithIconItem {
-    /** Дополнительные классы для корневого и внутренних элементов */
+    /** Дополнительные классы для внутренних элементов */
     classes?: {
         icon?: string;
         text?: string;

--- a/packages/ui-shared/src/components/TextWithIcon/__snapshots__/TextWithIconItem.test.tsx.snap
+++ b/packages/ui-shared/src/components/TextWithIcon/__snapshots__/TextWithIconItem.test.tsx.snap
@@ -22,3 +22,31 @@ exports[`<TextWithIconItem /> should render 1`] = `
   </div>
 </div>
 `;
+
+exports[`<TextWithIconItem /> should render with HTML and classes 1`] = `
+<div
+  className="mfui-text-with-icon-item mfui-text-with-icon-item_centering-on-mobile test-class"
+>
+  <div
+    className="mfui-text-with-icon-item__svg-icon icon-class"
+  >
+    <test-file-stub
+      style={
+        Object {
+          "fill": "#00B956",
+        }
+      }
+    />
+  </div>
+  <div
+    className="mfui-text-with-icon-item__text text-class"
+  >
+    First item 
+    <component
+      key="1"
+    >
+      with strong text
+    </component>
+  </div>
+</div>
+`;

--- a/packages/ui-shared/src/components/TextWithIcon/doc/TextWithIcon.example.mdx
+++ b/packages/ui-shared/src/components/TextWithIcon/doc/TextWithIcon.example.mdx
@@ -49,13 +49,13 @@ import Heart from '@megafon/ui-icons/basic-16-heart_16.svg';
 
 ```javascript
 
-В свойстве text поддерживаются некоторые HTML-теги: "<br>, <font color>, <a href>" и спецсимвол &nbsp.
+В свойстве text поддерживаются некоторые HTML-теги: "<br>, <b>, <font color>, <a href>" и спецсимвол &nbsp.
 
 ```
 
 <Playground>
     <TextWithIcon centeringOnMobile={false}>
-        <TextWithIconItem centeringOnMobile={false} text="Описание&nbspдолжно <a href='https://moscow.megafon.ru'>быть</a> <font color='#731982'>примерно</font> не более 130 символов.<br>Пишите содержательно, кратно и не будет проблем с текстовым контентом." icon={<Heart style={{ fill: '#00B956' }} />} />
+        <TextWithIconItem centeringOnMobile={false} text="Описание&nbspдолжно <a href='https://moscow.megafon.ru'>быть</a> <font color='#731982'>примерно</font> не более <b>130</b> символов.<br>Пишите содержательно, кратко и не будет проблем с текстовым контентом." icon={<Heart style={{ fill: '#00B956' }} />} />
         <TextWithIconItem centeringOnMobile={false} text="Специальные предложения для ваших клиентов" icon={<Star style={{ fill: '#00B956' }} />} />
         <TextWithIconItem centeringOnMobile={false} text="Понятная и простая реализация партнерстваих" icon={<Like style={{ fill: '#00B956' }} />} />
     </TextWithIcon>

--- a/packages/ui-shared/src/components/TextWithIcon/doc/TextWithIcon.example.mdx
+++ b/packages/ui-shared/src/components/TextWithIcon/doc/TextWithIcon.example.mdx
@@ -44,3 +44,19 @@ import Heart from '@megafon/ui-icons/basic-16-heart_16.svg';
         <TextWithIconItem centeringOnMobile={false} text="Понятная и простая реализация партнерстваих" icon={<Like style={{ fill: '#00B956' }} />} />
     </TextWithIcon>
 </Playground>
+
+## HTML-теги и спецсимволы
+
+```javascript
+
+В свойстве text поддерживаются некоторые HTML-теги: "<br>, <font color>, <a href>" и спецсимвол &nbsp.
+
+```
+
+<Playground>
+    <TextWithIcon centeringOnMobile={false}>
+        <TextWithIconItem centeringOnMobile={false} text="Описание&nbspдолжно <a href='https://moscow.megafon.ru'>быть</a> <font color='#731982'>примерно</font> не более 130 символов.<br>Пишите содержательно, кратно и не будет проблем с текстовым контентом." icon={<Heart style={{ fill: '#00B956' }} />} />
+        <TextWithIconItem centeringOnMobile={false} text="Специальные предложения для ваших клиентов" icon={<Star style={{ fill: '#00B956' }} />} />
+        <TextWithIconItem centeringOnMobile={false} text="Понятная и простая реализация партнерстваих" icon={<Like style={{ fill: '#00B956' }} />} />
+    </TextWithIcon>
+</Playground>


### PR DESCRIPTION
<!-- Autogenerated checksum:ab9cb505dca6ae5f4e3db5d4a21add24d10a1be1_44c4b6ad323a88f48d3b79191e3be4c44fa2ac14 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-shared/package.json
"version": "4.5.3"
"version": "4.6.0"
```
### Changelogs:
## :memo: packages/ui-shared/CHANGELOG.md
# [4.6.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@4.5.3...@megafon/ui-shared@4.6.0) (2022-12-05)


### Features

* **textwithicon:** fix playground ([44c4b6a](https://github.com/MegafonWebLab/megafon-ui/commit/44c4b6ad323a88f48d3b79191e3be4c44fa2ac14))
* **textwithiconitem:** add example and fix text ([3db8692](https://github.com/MegafonWebLab/megafon-ui/commit/3db869242615caacf1101e4fcff1877ee43c9c95))
* **textwithiconitem:** add render html and classes ([74e21bc](https://github.com/MegafonWebLab/megafon-ui/commit/74e21bcb78e3f4764ceb58d8fa102b6b000c5ae2))





