### PR TITLE
add alt prop for images

### DIFF
--- a/packages/ui-shared/src/components/BenefitsPictures/BenefitsPictures.tsx
+++ b/packages/ui-shared/src/components/BenefitsPictures/BenefitsPictures.tsx
@@ -162,7 +162,7 @@ const BenefitsPictures: React.FC<IBenefitsPicturesProps> = ({
     return (
         <div className={cn([className, classes.root])} ref={rootRef}>
             <Grid guttersLeft={currentGutter} hAlign={isGridCenterAlign ? 'center' : 'left'}>
-                {items.map(({ img, title, text }, index) => (
+                {items.map(({ img, title, text, alt }, index) => (
                     <GridColumn
                         {...(align === 'left'
                             ? getLeftConfig(items.length, index)
@@ -170,7 +170,7 @@ const BenefitsPictures: React.FC<IBenefitsPicturesProps> = ({
                         key={index}
                     >
                         <div className={cn('item', [classes.item])}>
-                            <img className={cn('img', { 'h-align': align })} src={img} alt="" />
+                            <img className={cn('img', { 'h-align': align })} src={img} alt={alt} />
                             <Header className={cn('title')} align={align} as="h3">
                                 {convert(title)}
                             </Header>
@@ -193,6 +193,7 @@ BenefitsPictures.propTypes = {
             title: PropTypes.string.isRequired,
             text: PropTypes.string.isRequired,
             img: PropTypes.string.isRequired,
+            alt: PropTypes.string,
         }).isRequired,
     ).isRequired,
     align: PropTypes.oneOf(['left', 'center']),

--- a/packages/ui-shared/src/components/BenefitsPictures/__snapshots__/BenefitPictures.test.tsx.snap
+++ b/packages/ui-shared/src/components/BenefitsPictures/__snapshots__/BenefitPictures.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<BenefitsPictures /> render with center horizontal align 1`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -49,7 +49,7 @@ exports[`<BenefitsPictures /> render with center horizontal align 1`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -89,7 +89,7 @@ exports[`<BenefitsPictures /> render with center horizontal align 2`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -118,7 +118,7 @@ exports[`<BenefitsPictures /> render with center horizontal align 2`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -146,7 +146,7 @@ exports[`<BenefitsPictures /> render with center horizontal align 2`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -186,7 +186,7 @@ exports[`<BenefitsPictures /> render with center horizontal align 3`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -217,7 +217,7 @@ exports[`<BenefitsPictures /> render with center horizontal align 3`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -245,7 +245,7 @@ exports[`<BenefitsPictures /> render with center horizontal align 3`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -276,7 +276,7 @@ exports[`<BenefitsPictures /> render with center horizontal align 3`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -316,7 +316,6 @@ exports[`<BenefitsPictures /> render with html in title and text 1`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="image.png"
         />
@@ -364,7 +363,6 @@ exports[`<BenefitsPictures /> render with html in title and text 1`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="image.png"
         />
@@ -404,7 +402,7 @@ exports[`<BenefitsPictures /> render with medium grid gap 1`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -435,7 +433,7 @@ exports[`<BenefitsPictures /> render with medium grid gap 1`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -475,7 +473,7 @@ exports[`<BenefitsPictures /> render with medium grid gap 2`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -504,7 +502,7 @@ exports[`<BenefitsPictures /> render with medium grid gap 2`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -532,7 +530,7 @@ exports[`<BenefitsPictures /> render with medium grid gap 2`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -572,7 +570,7 @@ exports[`<BenefitsPictures /> render with medium grid gap 3`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -603,7 +601,7 @@ exports[`<BenefitsPictures /> render with medium grid gap 3`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -631,7 +629,7 @@ exports[`<BenefitsPictures /> render with medium grid gap 3`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -662,7 +660,7 @@ exports[`<BenefitsPictures /> render with medium grid gap 3`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -702,7 +700,7 @@ exports[`<BenefitsPictures /> renders BenefitsPictures 1`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />
@@ -733,7 +731,7 @@ exports[`<BenefitsPictures /> renders BenefitsPictures 1`] = `
         className="mfui-benefits-pictures__item item-class"
       >
         <img
-          alt=""
+          alt="alt"
           className="mfui-benefits-pictures__img mfui-benefits-pictures__img_h-align_left"
           src="test-file-stub"
         />

--- a/packages/ui-shared/src/components/BenefitsPictures/doc/BenefitsPictures.docz.tsx
+++ b/packages/ui-shared/src/components/BenefitsPictures/doc/BenefitsPictures.docz.tsx
@@ -5,6 +5,7 @@ const getItems = (i, image) =>
         title: 'Интернет',
         text: 'Подключение к домашнему интернету осуществляется в удобное для вас время по технологиям Ethernet, Docsis.',
         img: image,
+        alt: 'alt',
     }));
 
 export const twoItems = getItems(2, img);

--- a/packages/ui-shared/src/components/BenefitsPictures/types.ts
+++ b/packages/ui-shared/src/components/BenefitsPictures/types.ts
@@ -5,7 +5,7 @@ export interface IBenefit {
     text: string;
     /** Изображение */
     img: string;
-    /** Текст для изображения */
+    /** Значение тега alt для изображения */
     alt?: string;
 }
 

--- a/packages/ui-shared/src/components/BenefitsPictures/types.ts
+++ b/packages/ui-shared/src/components/BenefitsPictures/types.ts
@@ -5,6 +5,8 @@ export interface IBenefit {
     text: string;
     /** Изображение */
     img: string;
+    /** Текст для изображения */
+    alt?: string;
 }
 
 type TGridSizeValues = '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';

--- a/packages/ui-shared/src/components/Card/Card.test.tsx
+++ b/packages/ui-shared/src/components/Card/Card.test.tsx
@@ -27,6 +27,7 @@ const dataAttrs = {
     button: { 'data-testid': 'button-test' },
 };
 const imageSrc = '/test-src';
+const imageAlt = 'image alt';
 
 describe('Card', () => {
     it('render component with required props', () => {
@@ -40,6 +41,7 @@ describe('Card', () => {
                 title={title}
                 text={text}
                 imageSrc={imageSrc}
+                imageAlt={imageAlt}
                 button={button}
                 link={link}
                 classes={classes}
@@ -82,7 +84,15 @@ describe('Card', () => {
 
     it('render component with img, if image source and svg source are specified', () => {
         const wrapper = shallow(
-            <Card title={title} text={text} svgSrc={svg} button={button} link={link} imageSrc={imageSrc} />,
+            <Card
+                title={title}
+                text={text}
+                svgSrc={svg}
+                button={button}
+                link={link}
+                imageSrc={imageSrc}
+                imageAlt={imageAlt}
+            />,
         );
         expect(wrapper).toMatchSnapshot();
     });
@@ -103,13 +113,23 @@ describe('Card', () => {
     });
 
     it('left align of the interactive element', () => {
-        const wrapper = shallow(<Card title={title} text={text} imageSrc={imageSrc} link={link} isLeftHAlign />);
+        const wrapper = shallow(
+            <Card title={title} text={text} imageSrc={imageSrc} imageAlt={imageAlt} link={link} isLeftHAlign />,
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
     it('disable left align if there is a button and link', () => {
         const wrapper = shallow(
-            <Card title={title} text={text} imageSrc={imageSrc} button={button} link={link} isLeftHAlign />,
+            <Card
+                title={title}
+                text={text}
+                imageSrc={imageSrc}
+                imageAlt={imageAlt}
+                button={button}
+                link={link}
+                isLeftHAlign
+            />,
         );
         expect(wrapper).toMatchSnapshot();
     });
@@ -130,7 +150,14 @@ describe('Card', () => {
 
     it('render with contain object fit', () => {
         const wrapper = shallow(
-            <Card title={title} text={text} imageSrc={imageSrc} button={button} objectFit={ObjectFit.CONTAIN} />,
+            <Card
+                title={title}
+                text={text}
+                imageSrc={imageSrc}
+                imageAlt={imageAlt}
+                button={button}
+                objectFit={ObjectFit.CONTAIN}
+            />,
         );
         expect(wrapper).toMatchSnapshot();
     });

--- a/packages/ui-shared/src/components/Card/Card.tsx
+++ b/packages/ui-shared/src/components/Card/Card.tsx
@@ -53,6 +53,8 @@ export interface ICard {
     rootRef?: Ref<HTMLDivElement>;
     /** Изображение в карточке */
     imageSrc?: string;
+    /** Текст для изображения */
+    imageAlt?: string;
     /** Иконка в карточке */
     svgSrc?: React.ReactNode;
     /** Заголовок карточки */
@@ -84,6 +86,7 @@ const Card: React.FC<ICard> = ({
     classes = {},
     rootRef,
     imageSrc,
+    imageAlt,
     svgSrc,
     title,
     text,
@@ -105,7 +108,7 @@ const Card: React.FC<ICard> = ({
             case !!imageSrc: {
                 return (
                     <div className={cn('pic-wrapper', { 'object-fit': objectFit })}>
-                        <img className={cn('img')} src={imageSrc} alt="" />
+                        <img className={cn('img')} src={imageSrc} alt={imageAlt} />
                     </div>
                 );
             }
@@ -117,7 +120,7 @@ const Card: React.FC<ICard> = ({
             default:
                 return null;
         }
-    }, [imageSrc, svgSrc, objectFit]);
+    }, [imageSrc, svgSrc, objectFit, imageAlt]);
 
     const renderLink = React.useCallback(() => {
         if (!link) {
@@ -236,6 +239,7 @@ Card.propTypes = {
         PropTypes.oneOfType([PropTypes.shape({ current: PropTypes.elementType }), PropTypes.any]),
     ]),
     imageSrc: PropTypes.string,
+    imageAlt: PropTypes.string,
     svgSrc: PropTypes.node,
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]).isRequired,
     text: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),

--- a/packages/ui-shared/src/components/Card/Card.tsx
+++ b/packages/ui-shared/src/components/Card/Card.tsx
@@ -53,7 +53,7 @@ export interface ICard {
     rootRef?: Ref<HTMLDivElement>;
     /** Изображение в карточке */
     imageSrc?: string;
-    /** Текст для изображения */
+    /** Значение тега alt для изображения */
     imageAlt?: string;
     /** Иконка в карточке */
     svgSrc?: React.ReactNode;

--- a/packages/ui-shared/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/packages/ui-shared/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`Card disable left align if there is a button and link 1`] = `
       className="mfui-card__pic-wrapper mfui-card__pic-wrapper_object-fit_fill"
     >
       <img
-        alt=""
+        alt="image alt"
         className="mfui-card__img"
         src="/test-src"
       />
@@ -114,7 +114,7 @@ exports[`Card left align of the interactive element 1`] = `
       className="mfui-card__pic-wrapper mfui-card__pic-wrapper_object-fit_fill"
     >
       <img
-        alt=""
+        alt="image alt"
         className="mfui-card__img"
         src="/test-src"
       />
@@ -223,7 +223,7 @@ exports[`Card render component with img, if image source and svg source are spec
       className="mfui-card__pic-wrapper mfui-card__pic-wrapper_object-fit_fill"
     >
       <img
-        alt=""
+        alt="image alt"
         className="mfui-card__img"
         src="/test-src"
       />
@@ -320,7 +320,7 @@ exports[`Card render component with optional props 1`] = `
       className="mfui-card__pic-wrapper mfui-card__pic-wrapper_object-fit_fill"
     >
       <img
-        alt=""
+        alt="image alt"
         className="mfui-card__img"
         src="/test-src"
       />
@@ -552,7 +552,7 @@ exports[`Card render with contain object fit 1`] = `
       className="mfui-card__pic-wrapper mfui-card__pic-wrapper_object-fit_contain"
     >
       <img
-        alt=""
+        alt="image alt"
         className="mfui-card__img"
         src="/test-src"
       />

--- a/packages/ui-shared/src/components/Instructions/Instructions.test.tsx
+++ b/packages/ui-shared/src/components/Instructions/Instructions.test.tsx
@@ -17,11 +17,13 @@ const items: InstructionItemType[] = [
         title: 'Test1',
         mediaUrl: 'ImgUrl1',
         isVideo: true,
+        imageAlt: 'alt1',
     },
     {
         title: 'Test2',
         mediaUrl: 'ImgUrl2',
         isVideo: false,
+        imageAlt: 'alt2',
     },
 ];
 

--- a/packages/ui-shared/src/components/Instructions/Instructions.tsx
+++ b/packages/ui-shared/src/components/Instructions/Instructions.tsx
@@ -32,6 +32,7 @@ export type InstructionItemType = {
     title: string | React.ReactNode | React.ReactNode[];
     mediaUrl: string;
     isVideo: boolean;
+    imageAlt?: string;
 };
 
 export interface IInstructionsProps {
@@ -151,13 +152,13 @@ const Instructions: React.FC<IInstructionsProps> = ({
                 onSlideChange={handleSlideChange}
                 className={cn('swiper')}
             >
-                {instructionItems.map(({ mediaUrl, isVideo }, i) => (
+                {instructionItems.map(({ mediaUrl, isVideo, imageAlt }, i) => (
                     <SwiperSlide className={swiperSlideCn} key={i + mediaUrl}>
                         {isVideo ? (
                             renderVideo(mediaUrl, i)
                         ) : (
                             <img
-                                alt=""
+                                alt={imageAlt}
                                 src={mediaUrl}
                                 {...filterDataAttrs(dataAttrs?.image, i + 1)}
                                 className={cn('swiper-img', [instructionItemImg])}
@@ -337,6 +338,7 @@ Instructions.propTypes = {
                 .isRequired,
             mediaUrl: PropTypes.string.isRequired,
             isVideo: PropTypes.bool.isRequired,
+            imageAlt: PropTypes.string,
         }).isRequired,
     ).isRequired,
     pictureAlign: PropTypes.oneOf([pictureAlignTypes.LEFT, pictureAlignTypes.RIGHT]),

--- a/packages/ui-shared/src/components/Instructions/__snapshots__/Instructions.test.tsx.snap
+++ b/packages/ui-shared/src/components/Instructions/__snapshots__/Instructions.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`<Instructions /> desktop resolution active slide will be changed 1`] = 
               key="1ImgUrl2"
             >
               <img
-                alt=""
+                alt="alt2"
                 className="mfui-instructions__swiper-img"
                 src="ImgUrl2"
               />
@@ -214,7 +214,7 @@ exports[`<Instructions /> desktop resolution should render with data-attributes 
               key="1ImgUrl2"
             >
               <img
-                alt=""
+                alt="alt2"
                 className="mfui-instructions__swiper-img"
                 data-testid="image-test[2]"
                 src="ImgUrl2"
@@ -381,7 +381,7 @@ exports[`<Instructions /> desktop resolution should render with default props 1`
               key="1ImgUrl2"
             >
               <img
-                alt=""
+                alt="alt2"
                 className="mfui-instructions__swiper-img"
                 src="ImgUrl2"
               />
@@ -548,7 +548,7 @@ exports[`<Instructions /> desktop resolution should render with pictureMask 1`] 
                 key="1ImgUrl2"
               >
                 <img
-                  alt=""
+                  alt="alt2"
                   className="mfui-instructions__swiper-img"
                   src="ImgUrl2"
                 />
@@ -716,7 +716,7 @@ exports[`<Instructions /> desktop resolution should render with pictureMask Ipho
                 key="1ImgUrl2"
               >
                 <img
-                  alt=""
+                  alt="alt2"
                   className="mfui-instructions__swiper-img"
                   src="ImgUrl2"
                 />
@@ -878,7 +878,7 @@ exports[`<Instructions /> desktop resolution should render with right side pictu
               key="1ImgUrl2"
             >
               <img
-                alt=""
+                alt="alt2"
                 className="mfui-instructions__swiper-img"
                 src="ImgUrl2"
               />
@@ -1041,7 +1041,7 @@ exports[`<Instructions /> mobile resolution should render with data-attributes 1
               key="1ImgUrl2"
             >
               <img
-                alt=""
+                alt="alt2"
                 className="mfui-instructions__swiper-img"
                 data-testid="image-test[2]"
                 src="ImgUrl2"
@@ -1162,11 +1162,13 @@ exports[`<Instructions /> mobile resolution should render with default props 1`]
   instructionItems={
     Array [
       Object {
+        "imageAlt": "alt1",
         "isVideo": true,
         "mediaUrl": "ImgUrl1",
         "title": "Test1",
       },
       Object {
+        "imageAlt": "alt2",
         "isVideo": false,
         "mediaUrl": "ImgUrl2",
         "title": "Test2",
@@ -1257,7 +1259,7 @@ exports[`<Instructions /> mobile resolution should render with default props 1`]
                                       class="swiper-slide mfui-instructions__slide"
                                     >
                                       <img
-                                        alt=""
+                                        alt="alt2"
                                         class="mfui-instructions__swiper-img"
                                         src="ImgUrl2"
                                       />
@@ -1289,7 +1291,7 @@ exports[`<Instructions /> mobile resolution should render with default props 1`]
                                     class="swiper-slide mfui-instructions__slide"
                                   >
                                     <img
-                                      alt=""
+                                      alt="alt2"
                                       class="mfui-instructions__swiper-img"
                                       src="ImgUrl2"
                                     />
@@ -1352,7 +1354,7 @@ exports[`<Instructions /> mobile resolution should render with default props 1`]
                                     class="swiper-slide mfui-instructions__slide"
                                   >
                                     <img
-                                      alt=""
+                                      alt="alt2"
                                       class="mfui-instructions__swiper-img"
                                       src="ImgUrl2"
                                     />
@@ -1433,7 +1435,7 @@ exports[`<Instructions /> mobile resolution should render with default props 1`]
                               "imagesLoaded": 0,
                               "imagesToLoad": Dom7 [
                                 <img
-                                  alt=""
+                                  alt="alt2"
                                   class="mfui-instructions__swiper-img"
                                   src="ImgUrl2"
                                 />,
@@ -1935,7 +1937,7 @@ exports[`<Instructions /> mobile resolution should render with default props 1`]
                                   class="swiper-slide mfui-instructions__slide"
                                 >
                                   <img
-                                    alt=""
+                                    alt="alt2"
                                     class="mfui-instructions__swiper-img"
                                     src="ImgUrl2"
                                   />
@@ -1995,7 +1997,7 @@ exports[`<Instructions /> mobile resolution should render with default props 1`]
                                       class="swiper-slide mfui-instructions__slide"
                                     >
                                       <img
-                                        alt=""
+                                        alt="alt2"
                                         class="mfui-instructions__swiper-img"
                                         src="ImgUrl2"
                                       />
@@ -2027,7 +2029,7 @@ exports[`<Instructions /> mobile resolution should render with default props 1`]
                                     class="swiper-slide mfui-instructions__slide"
                                   >
                                     <img
-                                      alt=""
+                                      alt="alt2"
                                       class="mfui-instructions__swiper-img"
                                       src="ImgUrl2"
                                     />
@@ -2090,7 +2092,7 @@ exports[`<Instructions /> mobile resolution should render with default props 1`]
                                     class="swiper-slide mfui-instructions__slide"
                                   >
                                     <img
-                                      alt=""
+                                      alt="alt2"
                                       class="mfui-instructions__swiper-img"
                                       src="ImgUrl2"
                                     />
@@ -2171,7 +2173,7 @@ exports[`<Instructions /> mobile resolution should render with default props 1`]
                               "imagesLoaded": 0,
                               "imagesToLoad": Dom7 [
                                 <img
-                                  alt=""
+                                  alt="alt2"
                                   class="mfui-instructions__swiper-img"
                                   src="ImgUrl2"
                                 />,
@@ -2673,7 +2675,7 @@ exports[`<Instructions /> mobile resolution should render with default props 1`]
                                   class="swiper-slide mfui-instructions__slide"
                                 >
                                   <img
-                                    alt=""
+                                    alt="alt2"
                                     class="mfui-instructions__swiper-img"
                                     src="ImgUrl2"
                                   />
@@ -2687,7 +2689,7 @@ exports[`<Instructions /> mobile resolution should render with default props 1`]
                             className="swiper-slide mfui-instructions__slide"
                           >
                             <img
-                              alt=""
+                              alt="alt2"
                               className="mfui-instructions__swiper-img"
                               src="ImgUrl2"
                             />
@@ -2813,11 +2815,13 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 1
   instructionItems={
     Array [
       Object {
+        "imageAlt": "alt1",
         "isVideo": true,
         "mediaUrl": "ImgUrl1",
         "title": "Test1",
       },
       Object {
+        "imageAlt": "alt2",
         "isVideo": false,
         "mediaUrl": "ImgUrl2",
         "title": "Test2",
@@ -2908,7 +2912,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 1
                                       class="swiper-slide mfui-instructions__slide"
                                     >
                                       <img
-                                        alt=""
+                                        alt="alt2"
                                         class="mfui-instructions__swiper-img"
                                         src="ImgUrl2"
                                       />
@@ -2940,7 +2944,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 1
                                     class="swiper-slide mfui-instructions__slide"
                                   >
                                     <img
-                                      alt=""
+                                      alt="alt2"
                                       class="mfui-instructions__swiper-img"
                                       src="ImgUrl2"
                                     />
@@ -3003,7 +3007,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 1
                                     class="swiper-slide mfui-instructions__slide"
                                   >
                                     <img
-                                      alt=""
+                                      alt="alt2"
                                       class="mfui-instructions__swiper-img"
                                       src="ImgUrl2"
                                     />
@@ -3084,7 +3088,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 1
                               "imagesLoaded": 0,
                               "imagesToLoad": Dom7 [
                                 <img
-                                  alt=""
+                                  alt="alt2"
                                   class="mfui-instructions__swiper-img"
                                   src="ImgUrl2"
                                 />,
@@ -3586,7 +3590,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 1
                                   class="swiper-slide mfui-instructions__slide"
                                 >
                                   <img
-                                    alt=""
+                                    alt="alt2"
                                     class="mfui-instructions__swiper-img"
                                     src="ImgUrl2"
                                   />
@@ -3646,7 +3650,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 1
                                       class="swiper-slide mfui-instructions__slide"
                                     >
                                       <img
-                                        alt=""
+                                        alt="alt2"
                                         class="mfui-instructions__swiper-img"
                                         src="ImgUrl2"
                                       />
@@ -3678,7 +3682,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 1
                                     class="swiper-slide mfui-instructions__slide"
                                   >
                                     <img
-                                      alt=""
+                                      alt="alt2"
                                       class="mfui-instructions__swiper-img"
                                       src="ImgUrl2"
                                     />
@@ -3741,7 +3745,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 1
                                     class="swiper-slide mfui-instructions__slide"
                                   >
                                     <img
-                                      alt=""
+                                      alt="alt2"
                                       class="mfui-instructions__swiper-img"
                                       src="ImgUrl2"
                                     />
@@ -3822,7 +3826,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 1
                               "imagesLoaded": 0,
                               "imagesToLoad": Dom7 [
                                 <img
-                                  alt=""
+                                  alt="alt2"
                                   class="mfui-instructions__swiper-img"
                                   src="ImgUrl2"
                                 />,
@@ -4324,7 +4328,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 1
                                   class="swiper-slide mfui-instructions__slide"
                                 >
                                   <img
-                                    alt=""
+                                    alt="alt2"
                                     class="mfui-instructions__swiper-img"
                                     src="ImgUrl2"
                                   />
@@ -4338,7 +4342,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 1
                             className="swiper-slide mfui-instructions__slide"
                           >
                             <img
-                              alt=""
+                              alt="alt2"
                               className="mfui-instructions__swiper-img"
                               src="ImgUrl2"
                             />
@@ -4464,11 +4468,13 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 2
   instructionItems={
     Array [
       Object {
+        "imageAlt": "alt1",
         "isVideo": true,
         "mediaUrl": "ImgUrl1",
         "title": "Test1",
       },
       Object {
+        "imageAlt": "alt2",
         "isVideo": false,
         "mediaUrl": "ImgUrl2",
         "title": "Test2",
@@ -4559,7 +4565,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 2
                                       class="swiper-slide mfui-instructions__slide"
                                     >
                                       <img
-                                        alt=""
+                                        alt="alt2"
                                         class="mfui-instructions__swiper-img"
                                         src="ImgUrl2"
                                       />
@@ -4591,7 +4597,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 2
                                     class="swiper-slide mfui-instructions__slide"
                                   >
                                     <img
-                                      alt=""
+                                      alt="alt2"
                                       class="mfui-instructions__swiper-img"
                                       src="ImgUrl2"
                                     />
@@ -4654,7 +4660,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 2
                                     class="swiper-slide mfui-instructions__slide"
                                   >
                                     <img
-                                      alt=""
+                                      alt="alt2"
                                       class="mfui-instructions__swiper-img"
                                       src="ImgUrl2"
                                     />
@@ -4735,7 +4741,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 2
                               "imagesLoaded": 0,
                               "imagesToLoad": Dom7 [
                                 <img
-                                  alt=""
+                                  alt="alt2"
                                   class="mfui-instructions__swiper-img"
                                   src="ImgUrl2"
                                 />,
@@ -5237,7 +5243,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 2
                                   class="swiper-slide mfui-instructions__slide"
                                 >
                                   <img
-                                    alt=""
+                                    alt="alt2"
                                     class="mfui-instructions__swiper-img"
                                     src="ImgUrl2"
                                   />
@@ -5297,7 +5303,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 2
                                       class="swiper-slide mfui-instructions__slide"
                                     >
                                       <img
-                                        alt=""
+                                        alt="alt2"
                                         class="mfui-instructions__swiper-img"
                                         src="ImgUrl2"
                                       />
@@ -5329,7 +5335,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 2
                                     class="swiper-slide mfui-instructions__slide"
                                   >
                                     <img
-                                      alt=""
+                                      alt="alt2"
                                       class="mfui-instructions__swiper-img"
                                       src="ImgUrl2"
                                     />
@@ -5392,7 +5398,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 2
                                     class="swiper-slide mfui-instructions__slide"
                                   >
                                     <img
-                                      alt=""
+                                      alt="alt2"
                                       class="mfui-instructions__swiper-img"
                                       src="ImgUrl2"
                                     />
@@ -5473,7 +5479,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 2
                               "imagesLoaded": 0,
                               "imagesToLoad": Dom7 [
                                 <img
-                                  alt=""
+                                  alt="alt2"
                                   class="mfui-instructions__swiper-img"
                                   src="ImgUrl2"
                                 />,
@@ -5975,7 +5981,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 2
                                   class="swiper-slide mfui-instructions__slide"
                                 >
                                   <img
-                                    alt=""
+                                    alt="alt2"
                                     class="mfui-instructions__swiper-img"
                                     src="ImgUrl2"
                                   />
@@ -5989,7 +5995,7 @@ exports[`<Instructions /> mobile resolution should rerender when window resize 2
                             className="swiper-slide mfui-instructions__slide"
                           >
                             <img
-                              alt=""
+                              alt="alt2"
                               className="mfui-instructions__swiper-img"
                               src="ImgUrl2"
                             />
@@ -6161,7 +6167,7 @@ exports[`<Instructions /> should render component with additional text 1`] = `
               key="1ImgUrl2"
             >
               <img
-                alt=""
+                alt="alt2"
                 className="mfui-instructions__swiper-img"
                 src="ImgUrl2"
               />
@@ -6328,7 +6334,7 @@ exports[`<Instructions /> should render with children 1`] = `
               key="1ImgUrl2"
             >
               <img
-                alt=""
+                alt="alt2"
                 className="mfui-instructions__swiper-img"
                 src="ImgUrl2"
               />
@@ -6494,7 +6500,7 @@ exports[`<Instructions /> should render with classes props 1`] = `
               key="1ImgUrl2"
             >
               <img
-                alt=""
+                alt="alt2"
                 className="mfui-instructions__swiper-img instructionItemImg"
                 src="ImgUrl2"
               />

--- a/packages/ui-shared/src/components/PictureWithDescription/PictureWithDescription.test.tsx
+++ b/packages/ui-shared/src/components/PictureWithDescription/PictureWithDescription.test.tsx
@@ -4,6 +4,7 @@ import PictureWithDescription, { pictureAlignTypes, IPictureWithDescriptionProps
 
 const props: IPictureWithDescriptionProps = {
     pictureUrl: '/testUrl',
+    pictureAlt: 'alt text',
 };
 
 describe('<PictureWithDescription />', () => {

--- a/packages/ui-shared/src/components/PictureWithDescription/PictureWithDescription.tsx
+++ b/packages/ui-shared/src/components/PictureWithDescription/PictureWithDescription.tsx
@@ -27,7 +27,7 @@ export interface IPictureWithDescriptionProps {
     pictureUrl: string;
     /** Расположение изображения */
     pictureAlign?: PictureAlignTypesType;
-    /** Текст для изображения */
+    /** Значение тега alt для изображения */
     pictureAlt?: string;
     /** Выравнивание текста по верхнему краю */
     isTextTopAlign?: boolean;

--- a/packages/ui-shared/src/components/PictureWithDescription/PictureWithDescription.tsx
+++ b/packages/ui-shared/src/components/PictureWithDescription/PictureWithDescription.tsx
@@ -27,6 +27,8 @@ export interface IPictureWithDescriptionProps {
     pictureUrl: string;
     /** Расположение изображения */
     pictureAlign?: PictureAlignTypesType;
+    /** Текст для изображения */
+    pictureAlt?: string;
     /** Выравнивание текста по верхнему краю */
     isTextTopAlign?: boolean;
 }
@@ -39,12 +41,13 @@ const PictureWithDescription: React.FC<IPictureWithDescriptionProps> = ({
     title,
     pictureUrl,
     pictureAlign = 'left',
+    pictureAlt,
     isTextTopAlign,
     children,
 }) => (
     <div className={cn([className, classes.root])} ref={rootRef}>
         <div className={cn('picture', { align: pictureAlign })}>
-            <img className={cn('img')} src={pictureUrl} alt="" />
+            <img className={cn('img')} src={pictureUrl} alt={pictureAlt} />
         </div>
         <div className={cn('articles', { align: pictureAlign, 'text-top-align': isTextTopAlign })}>
             {!!title && (
@@ -70,6 +73,7 @@ PictureWithDescription.propTypes = {
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
     pictureUrl: PropTypes.string.isRequired,
     pictureAlign: PropTypes.oneOf([pictureAlignTypes.LEFT, pictureAlignTypes.RIGHT]),
+    pictureAlt: PropTypes.string,
     isTextTopAlign: PropTypes.bool,
 };
 

--- a/packages/ui-shared/src/components/PictureWithDescription/__snapshots__/PictureWithDescription.test.tsx.snap
+++ b/packages/ui-shared/src/components/PictureWithDescription/__snapshots__/PictureWithDescription.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<PictureWithDescription /> should render with custom classes 1`] = `
     className="mfui-picture-with-description__picture mfui-picture-with-description__picture_align_left"
   >
     <img
-      alt=""
+      alt="alt text"
       className="mfui-picture-with-description__img"
       src="/testUrl"
     />
@@ -39,7 +39,7 @@ exports[`<PictureWithDescription /> should render with default props 1`] = `
     className="mfui-picture-with-description__picture mfui-picture-with-description__picture_align_left"
   >
     <img
-      alt=""
+      alt="alt text"
       className="mfui-picture-with-description__img"
       src="/testUrl"
     />
@@ -64,7 +64,7 @@ exports[`<PictureWithDescription /> should render with right side picture 1`] = 
     className="mfui-picture-with-description__picture mfui-picture-with-description__picture_align_right"
   >
     <img
-      alt=""
+      alt="alt text"
       className="mfui-picture-with-description__img"
       src="/testUrl"
     />
@@ -89,7 +89,7 @@ exports[`<PictureWithDescription /> should render with title 1`] = `
     className="mfui-picture-with-description__picture mfui-picture-with-description__picture_align_left"
   >
     <img
-      alt=""
+      alt="alt text"
       className="mfui-picture-with-description__img"
       src="/testUrl"
     />
@@ -120,7 +120,7 @@ exports[`<PictureWithDescription /> should render with top align text 1`] = `
     className="mfui-picture-with-description__picture mfui-picture-with-description__picture_align_left"
   >
     <img
-      alt=""
+      alt="alt text"
       className="mfui-picture-with-description__img"
       src="/testUrl"
     />

--- a/packages/ui-shared/src/components/TextBox/TextBoxPicture.test.tsx
+++ b/packages/ui-shared/src/components/TextBox/TextBoxPicture.test.tsx
@@ -26,4 +26,10 @@ describe('TextBoxPicture', () => {
         const wrapper = shallow(<TextBoxPicture {...props} margin={pictureMarginTypes.BIG_TOP} />);
         expect(wrapper).toMatchSnapshot();
     });
+
+    it('render with alt text', () => {
+        const wrapper = shallow(<TextBoxPicture {...props} alt="alt text" />);
+
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/packages/ui-shared/src/components/TextBox/TextBoxPicture.tsx
+++ b/packages/ui-shared/src/components/TextBox/TextBoxPicture.tsx
@@ -17,7 +17,7 @@ export interface ITextBoxPictureProps {
     url: string;
     /** Значение вертикальных отступов */
     margin?: PictureMarginTypesType;
-    /** Текст для изображения */
+    /** Значение тега alt для изображения */
     alt?: string;
 }
 

--- a/packages/ui-shared/src/components/TextBox/TextBoxPicture.tsx
+++ b/packages/ui-shared/src/components/TextBox/TextBoxPicture.tsx
@@ -17,12 +17,14 @@ export interface ITextBoxPictureProps {
     url: string;
     /** Значение вертикальных отступов */
     margin?: PictureMarginTypesType;
+    /** Текст для изображения */
+    alt?: string;
 }
 
 const cn = cnCreate('mfui-text-box-picture');
-const TextBoxPicture: React.FC<ITextBoxPictureProps> = ({ url, margin = pictureMarginTypes.DEFAULT }) => (
+const TextBoxPicture: React.FC<ITextBoxPictureProps> = ({ url, margin = pictureMarginTypes.DEFAULT, alt }) => (
     <div className={cn({ margin })}>
-        <img className={cn('img')} src={url} alt="" />
+        <img className={cn('img')} src={url} alt={alt} />
     </div>
 );
 
@@ -34,6 +36,7 @@ TextBoxPicture.propTypes = {
         pictureMarginTypes.BIG_BOTTOM,
         pictureMarginTypes.BIG_VERTICAL,
     ]),
+    alt: PropTypes.string,
 };
 
 export default TextBoxPicture;

--- a/packages/ui-shared/src/components/TextBox/__snapshots__/TextBoxPicture.test.tsx.snap
+++ b/packages/ui-shared/src/components/TextBox/__snapshots__/TextBoxPicture.test.tsx.snap
@@ -1,11 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TextBoxPicture render with alt text 1`] = `
+<div
+  className="mfui-text-box-picture mfui-text-box-picture_margin_default"
+>
+  <img
+    alt="alt text"
+    className="mfui-text-box-picture__img"
+    src="#"
+  />
+</div>
+`;
+
 exports[`TextBoxPicture render with big bottom margin 1`] = `
 <div
   className="mfui-text-box-picture mfui-text-box-picture_margin_big-bottom"
 >
   <img
-    alt=""
     className="mfui-text-box-picture__img"
     src="#"
   />
@@ -17,7 +28,6 @@ exports[`TextBoxPicture render with big top margin 1`] = `
   className="mfui-text-box-picture mfui-text-box-picture_margin_big-top"
 >
   <img
-    alt=""
     className="mfui-text-box-picture__img"
     src="#"
   />
@@ -29,7 +39,6 @@ exports[`TextBoxPicture render with big vertical margins 1`] = `
   className="mfui-text-box-picture mfui-text-box-picture_margin_big-vertical"
 >
   <img
-    alt=""
     className="mfui-text-box-picture__img"
     src="#"
   />
@@ -41,7 +50,6 @@ exports[`TextBoxPicture render with default props 1`] = `
   className="mfui-text-box-picture mfui-text-box-picture_margin_default"
 >
   <img
-    alt=""
     className="mfui-text-box-picture__img"
     src="#"
   />

--- a/packages/ui-shared/src/components/VideoBanner/VideoBanner.test.tsx
+++ b/packages/ui-shared/src/components/VideoBanner/VideoBanner.test.tsx
@@ -52,6 +52,7 @@ describe('<VideoBanner />', () => {
                 imageTablet={imageTablet}
                 imageDesktop={imageDesktop}
                 imageDesktopWide={imageDesktopWide}
+                imageAlt="alt text"
             />,
         );
 

--- a/packages/ui-shared/src/components/VideoBanner/VideoBanner.tsx
+++ b/packages/ui-shared/src/components/VideoBanner/VideoBanner.tsx
@@ -121,6 +121,8 @@ interface IVideoBannerProps {
     imageDesktop?: string;
     /** Изображение для большого компьютерного разрешения */
     imageDesktopWide?: string;
+    /** Текст для изображения */
+    imageAlt?: string;
     /** Хлебные крошки */
     breadcrumbs?: BreadCrumbsItemsType;
     /** Включить микроразметку хлебных крошек */
@@ -138,6 +140,7 @@ const VideoBanner: React.FC<IVideoBannerProps> = ({
     imageTablet,
     imageDesktop = '',
     imageDesktopWide = '',
+    imageAlt,
     content,
     isMuted = true,
     breadcrumbs,
@@ -300,7 +303,7 @@ const VideoBanner: React.FC<IVideoBannerProps> = ({
                             <source media={`(min-width: ${breakpoints.DESKTOP_SMALL_START}px)`} srcSet={imageDesktop} />
                             <source media={`(min-width: ${breakpoints.MOBILE_BIG_START}px)`} srcSet={imageTablet} />
 
-                            <img className={cn('background-image')} src={imageMobile} alt="" />
+                            <img className={cn('background-image')} src={imageMobile} alt={imageAlt} />
                         </picture>
                     )}
                 </div>
@@ -352,6 +355,7 @@ VideoBanner.propTypes = {
     imageTablet: PropTypes.string.isRequired,
     imageDesktop: PropTypes.string,
     imageDesktopWide: PropTypes.string,
+    imageAlt: PropTypes.string,
     breadcrumbs: PropTypes.arrayOf(
         PropTypes.shape({
             title: PropTypes.string.isRequired,

--- a/packages/ui-shared/src/components/VideoBanner/VideoBanner.tsx
+++ b/packages/ui-shared/src/components/VideoBanner/VideoBanner.tsx
@@ -121,7 +121,7 @@ interface IVideoBannerProps {
     imageDesktop?: string;
     /** Изображение для большого компьютерного разрешения */
     imageDesktopWide?: string;
-    /** Текст для изображения */
+    /** Значение тега alt для изображения */
     imageAlt?: string;
     /** Хлебные крошки */
     breadcrumbs?: BreadCrumbsItemsType;

--- a/packages/ui-shared/src/components/VideoBanner/__snapshots__/VideoBanner.test.tsx.snap
+++ b/packages/ui-shared/src/components/VideoBanner/__snapshots__/VideoBanner.test.tsx.snap
@@ -127,7 +127,6 @@ exports[`<VideoBanner /> render component with breadcrumbs 1`] = `
           srcSet="imageTablet"
         />
         <img
-          alt=""
           className="mfui-video-banner__background-image"
           src="imageMobile"
         />
@@ -233,7 +232,6 @@ exports[`<VideoBanner /> render component with classes 1`] = `
           srcSet="imageTablet"
         />
         <img
-          alt=""
           className="mfui-video-banner__background-image"
           src="imageMobile"
         />
@@ -266,7 +264,6 @@ exports[`<VideoBanner /> render component with dataAttrs 1`] = `
           srcSet="imageTablet"
         />
         <img
-          alt=""
           className="mfui-video-banner__background-image"
           src="imageMobile"
         />
@@ -372,7 +369,6 @@ exports[`<VideoBanner /> render component with non default buttonColor 1`] = `
           srcSet="imageTablet"
         />
         <img
-          alt=""
           className="mfui-video-banner__background-image"
           src="imageMobile"
         />
@@ -404,7 +400,7 @@ exports[`<VideoBanner /> render component with pictures 1`] = `
           srcSet="imageTablet"
         />
         <img
-          alt=""
+          alt="alt text"
           className="mfui-video-banner__background-image"
           src="imageMobile"
         />
@@ -510,7 +506,6 @@ exports[`<VideoBanner /> render component with pictures and content 1`] = `
           srcSet="imageTablet"
         />
         <img
-          alt=""
           className="mfui-video-banner__background-image"
           src="imageMobile"
         />
@@ -618,7 +613,6 @@ exports[`<VideoBanner /> render component with pictures and download links conte
           srcSet="imageTablet"
         />
         <img
-          alt=""
           className="mfui-video-banner__background-image"
           src="imageMobile"
         />
@@ -724,7 +718,6 @@ exports[`<VideoBanner /> render component with pictures and non default content 
           srcSet="imageTablet"
         />
         <img
-          alt=""
           className="mfui-video-banner__background-image"
           src="imageMobile"
         />
@@ -830,7 +823,6 @@ exports[`<VideoBanner /> render component with the different content text color 
           srcSet="imageTablet"
         />
         <img
-          alt=""
           className="mfui-video-banner__background-image"
           src="imageMobile"
         />
@@ -923,7 +915,6 @@ exports[`<VideoBanner /> render component without button 1`] = `
           srcSet="imageTablet"
         />
         <img
-          alt=""
           className="mfui-video-banner__background-image"
           src="imageMobile"
         />
@@ -1168,7 +1159,6 @@ exports[`<VideoBanner /> tests with local window render desktop image on relevan
                 srcSet="imageTablet"
               />
               <img
-                alt=""
                 className="mfui-video-banner__background-image"
                 src="imageMobile"
               />
@@ -1215,7 +1205,6 @@ exports[`<VideoBanner /> tests with local window render mobile image on relevant
                 srcSet="imageTablet"
               />
               <img
-                alt=""
                 className="mfui-video-banner__background-image"
                 src="imageMobile"
               />
@@ -1262,7 +1251,6 @@ exports[`<VideoBanner /> tests with local window render tablet image on relevant
                 srcSet="imageTablet"
               />
               <img
-                alt=""
                 className="mfui-video-banner__background-image"
                 src="imageMobile"
               />
@@ -1349,7 +1337,6 @@ exports[`<VideoBanner /> tests with local window render wide desktop image on re
                 srcSet="imageTablet"
               />
               <img
-                alt=""
                 className="mfui-video-banner__background-image"
                 src="imageMobile"
               />
@@ -1731,7 +1718,6 @@ exports[`<VideoBanner /> tests with local window should not render video on mobi
           srcSet="imageDesktop"
         />
         <img
-          alt=""
           className="mfui-video-banner__background-image"
           src="imageMobile"
         />


### PR DESCRIPTION
<!-- Autogenerated checksum:9def04b4abf47ad1bc0cfd3bb0430851b56b60ee_51acd8c029e5734036d7543a7bfc6f71741ca0e2 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-shared/package.json
"version": "4.11.0"
"version": "4.12.0"
```
### Changelogs:
## :memo: packages/ui-shared/CHANGELOG.md
# [4.12.0](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@4.11.0...@megafon/ui-shared@4.12.0) (2023-02-06)


### Features

* **benefitpictures:** add alt prop for images ([3fd19e7](https://github.com/MegafonWebLab/megafon-ui/commit/3fd19e718068db8d418adccbb1812e4e8dd6e090))
* **card:** add alt prop for image ([a56a159](https://github.com/MegafonWebLab/megafon-ui/commit/a56a1595b1114e63aa80d9f8976bfb8d54b871db))
* **instructions:** add alt prop for images ([94d4750](https://github.com/MegafonWebLab/megafon-ui/commit/94d4750a51a4d3e848c319ed98a31b3fd241e733))
* **picturewithdescription:** add alt prop for image ([0ed9e19](https://github.com/MegafonWebLab/megafon-ui/commit/0ed9e195b00c41a2a736de741af82b3808eb1677))
* **textboxpicture:** add alt prop for image ([6df38e2](https://github.com/MegafonWebLab/megafon-ui/commit/6df38e23d9a42fbb8833c0f4968fd6f6ff4f28b7))
* **videobanner:** add alt prop for image ([3ec8c6c](https://github.com/MegafonWebLab/megafon-ui/commit/3ec8c6cda08b42fe8f36b9bee029ad0c3ad18d5f))





