### PR TITLE
fix(icons): replace Apple-map.svg icon

### DIFF
--- a/packages/ui-icons/src/Service-logos/24/Apple-map.svg
+++ b/packages/ui-icons/src/Service-logos/24/Apple-map.svg
@@ -1,1 +1,10 @@
-<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><circle id="a" cx="12" cy="12" r="12"/></defs><g transform="translate(4 4)" fill="none" fill-rule="evenodd"><mask id="b" fill="#fff"><use xlink:href="#a"/></mask><use fill="#FFF" xlink:href="#a"/><path fill="#E7DFCA" mask="url(#b)" d="M0 0h8.16v23.84H0z"/><path fill="#78CA41" mask="url(#b)" d="M15.84 0H24v8.053h-8.16z"/><path fill="#F9CBD6" mask="url(#b)" d="M15.84 15.787H24v8.053h-8.16z"/><circle fill="#037AFF" mask="url(#b)" cx="11.893" cy="11.84" r="5.867"/><path fill="#FFF" mask="url(#b)" d="m9.56 15.349 2.32-8.087 2.306 8.087-2.306-2.376z"/><circle stroke="#000" opacity=".145" mask="url(#b)" cx="12" cy="12" r="11.5"/></g></svg>
+<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16 28C22.6 28 28 22.6 28 16C28 9.4 22.6 4 16 4C9.4 4 4 9.4 4 16C4 22.6 9.4 28 16 28Z" fill="white"/>
+<path d="M19.8 12.2V4.59998C23.3 5.79998 26.1 8.49998 27.3 12V12.1H19.8V12.2Z" fill="#78CA41"/>
+<path d="M19.8 19.8V27.3C23.3 26.1 26.1 23.4 27.3 19.9V19.8H19.8Z" fill="#F9CBD6"/>
+<path d="M12.2 4.59998C7.4 6.19998 4 10.7 4 16C4 21.3 7.4 25.8 12.2 27.4V4.59998Z" fill="#E7DFCA"/>
+<path d="M15.9 21.7C19.1 21.7 21.8 19.1 21.8 15.8C21.8 12.5 19.1 10 15.9 10C12.7 10 10 12.6 10 15.8C10 19 12.7 21.7 15.9 21.7Z" fill="#037AFF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13.6 19.3L15.9 11.2L18.2 19.3L15.9 17L13.6 19.3Z" fill="white"/>
+<path opacity="0.14" fill-rule="evenodd" clip-rule="evenodd" d="M4 16C4 9.4 9.4 4 16 4C22.6 4 28 9.4 28 16C28 22.6 22.6 28 16 28C9.4 28 4 22.6 4 16ZM16 5C9.9 5 5 9.9 5 16C5 22.1 9.9 27 16 27C22.1 27 27 22.1 27 16C27 9.9 22.1 5 16 5Z" fill="black"/>
+<path d="M16 5C22.1 5 27 9.9 27 16C27 22.1 22.1 27 16 27C9.9 27 5 22.1 5 16C5 9.9 9.9 5 16 5ZM16 4C9.4 4 4 9.4 4 16C4 22.6 9.4 28 16 28C22.6 28 28 22.6 28 16C28 9.4 22.6 4 16 4Z" fill="#D1CABA"/>
+</svg>


### PR DESCRIPTION
<!-- Autogenerated checksum:43725eddf6f23f91c95f9f7c932e9b9589a4af04_90a4a87d27cdd565d50295956165c26b4739b40f -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "4.14.2"
"version": "4.14.3"

ui-icons/package.json
"version": "2.8.0"
"version": "2.8.1"

ui-shared/package.json
"version": "4.15.0"
"version": "4.15.1"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
## [4.14.3](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@4.14.2...@megafon/ui-core@4.14.3) (2023-03-21)

**Note:** Version bump only for package @megafon/ui-core





## :memo: packages/ui-icons/CHANGELOG.md
## [2.8.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-icons@2.8.0...@megafon/ui-icons@2.8.1) (2023-03-21)


### Bug Fixes

* **icons:** replace Apple-map.svg icon for fix missing <mask /> issue after SVGO ([90a4a87](https://github.com/MegafonWebLab/megafon-ui/commit/90a4a87d27cdd565d50295956165c26b4739b40f))





## :memo: packages/ui-shared/CHANGELOG.md
## [4.15.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@4.15.0...@megafon/ui-shared@4.15.1) (2023-03-21)

**Note:** Version bump only for package @megafon/ui-shared





