### PR TITLE
fix(pricebadge): new props size and subtitle

### DIFF
--- a/packages/ui-core/src/components/Badges/components/PriceBadge/PriceBadge.less
+++ b/packages/ui-core/src/components/Badges/components/PriceBadge/PriceBadge.less
@@ -75,6 +75,12 @@
         }
     }
 
+    &_size_big {
+        font-size: 15px;
+        line-height: 18px;
+        padding: 12px 12px 12px 4px;
+    }
+
     &__text {
         .fontFamily();
 
@@ -88,5 +94,20 @@
     &__icon {
         height: 20px;
         width: 20px;
+        min-width: 20px;
+    }
+
+    &_size_big & {
+        &__icon {
+            height: 32px;
+            width: 32px;
+            min-width: 32px;    
+        }
+
+        &__sub-title {
+            font-size: 12px;
+            line-height: 18px;
+            margin-top: 2px;
+        }
     }
 }

--- a/packages/ui-core/src/components/Badges/components/PriceBadge/PriceBadge.test.tsx
+++ b/packages/ui-core/src/components/Badges/components/PriceBadge/PriceBadge.test.tsx
@@ -50,4 +50,25 @@ describe('<PriceBadge />', () => {
 
         expect(getByTestId('root')).toHaveClass('mfui-price-badge_adaptive');
     });
+
+    it('should render big size badge with subTitle', () => {
+        const { getByTestId, getByText } = render(
+            <PriceBadge dataAttrs={dataAttrs} size="big" subTitle="subTitle">
+                text
+            </PriceBadge>,
+        );
+
+        expect(getByTestId('root')).toHaveClass('mfui-price-badge_size_big');
+        expect(getByText('subTitle')).toBeInTheDocument();
+    });
+
+    it('should render small size without subTitle', () => {
+        const { queryByText } = render(
+            <PriceBadge dataAttrs={dataAttrs} size="small" subTitle="subTitle">
+                text
+            </PriceBadge>,
+        );
+
+        expect(queryByText('subTitle')).toBeNull();
+    });
 });

--- a/packages/ui-core/src/components/Badges/components/PriceBadge/PriceBadge.tsx
+++ b/packages/ui-core/src/components/Badges/components/PriceBadge/PriceBadge.tsx
@@ -4,6 +4,10 @@ import AttentionIcon from '@megafon/ui-icons/system-16-attention_16.svg';
 import CheckIcon from '@megafon/ui-icons/system-16-check_invert_16.svg';
 import PriceIcon from '@megafon/ui-icons/system-16-price_16.svg';
 import TimerIcon from '@megafon/ui-icons/system-16-timer_16.svg';
+import AttentionIconBig from '@megafon/ui-icons/system-24-attention_24.svg';
+import CheckIconBig from '@megafon/ui-icons/system-24-check_invert_24.svg';
+import PriceIconBig from '@megafon/ui-icons/system-24-price_24.svg';
+import TimerIconBig from '@megafon/ui-icons/system-24-timer_24.svg';
 import * as PropTypes from 'prop-types';
 import './PriceBadge.less';
 
@@ -21,18 +25,32 @@ export const PriceBadgeIcon = {
     ATTENTION: 'attention',
 } as const;
 
+export const PriseBadgeSize = {
+    SMALL: 'small',
+    BIG: 'big',
+} as const;
+
 type PriceBadgeThemeType = typeof PriceBadgeTheme[keyof typeof PriceBadgeTheme];
 type PriceBadgeIconType = typeof PriceBadgeIcon[keyof typeof PriceBadgeIcon];
+type PriseBadgeSizeType = typeof PriseBadgeSize[keyof typeof PriseBadgeSize];
 
-const getPriceBadgeIcon = (iconType: PriceBadgeIconType) => {
-    switch (iconType) {
-        case PriceBadgeIcon.TIMER:
-            return TimerIcon;
-        case PriceBadgeIcon.PRICE:
+const getPriceBadgeIcon = (iconType: PriceBadgeIconType, size: PriseBadgeSizeType) => {
+    const isBigIcon = size === PriseBadgeSize.BIG;
+
+    switch (true) {
+        case iconType === PriceBadgeIcon.TIMER && isBigIcon:
+            return TimerIconBig;
+        case iconType === PriceBadgeIcon.PRICE && isBigIcon:
+            return PriceIconBig;
+        case iconType === PriceBadgeIcon.CHECK && isBigIcon:
+            return CheckIconBig;
+        case iconType === PriceBadgeIcon.ATTENTION && isBigIcon:
+            return AttentionIconBig;
+        case iconType === PriceBadgeIcon.PRICE:
             return PriceIcon;
-        case PriceBadgeIcon.CHECK:
+        case iconType === PriceBadgeIcon.CHECK:
             return CheckIcon;
-        case PriceBadgeIcon.ATTENTION:
+        case iconType === PriceBadgeIcon.ATTENTION:
             return AttentionIcon;
         default:
             return TimerIcon;
@@ -48,6 +66,10 @@ export interface IPriceBadgeProps {
     theme?: PriceBadgeThemeType;
     /** Дополнительный класс корневого элемента */
     className?: string;
+    /** Размер бейджа */
+    size?: PriseBadgeSizeType;
+    /** Дополнительный текст (только для size="big") */
+    subTitle?: string;
     /** Дополнительные data-атрибуты к внутренним элементам */
     dataAttrs?: {
         root?: Record<string, string>;
@@ -60,18 +82,24 @@ const PriceBadge: React.FC<IPriceBadgeProps> = ({
     iconType = 'timer',
     isAdaptive = false,
     theme = 'grey',
+    size = 'small',
+    subTitle,
     className,
     dataAttrs,
     children,
 }) => {
-    const Icon = getPriceBadgeIcon(iconType);
+    const Icon = getPriceBadgeIcon(iconType, size);
+    const showSubTitle = size === 'big' && !!subTitle;
 
     return (
-        <div {...filterDataAttrs(dataAttrs?.root)} className={cn({ theme, adaptive: isAdaptive }, className)}>
+        <div {...filterDataAttrs(dataAttrs?.root)} className={cn({ theme, adaptive: isAdaptive, size }, className)}>
             <div className={cn('icon-container')}>
                 <Icon className={cn('icon')} />
             </div>
-            <span className={cn('text')}>{children}</span>
+            <div className={cn('text')}>
+                <div>{children}</div>
+                {showSubTitle && <div className={cn('sub-title')}>{subTitle}</div>}
+            </div>
         </div>
     );
 };
@@ -80,6 +108,8 @@ PriceBadge.propTypes = {
     isAdaptive: PropTypes.bool,
     iconType: PropTypes.oneOf(Object.values(PriceBadgeIcon)),
     theme: PropTypes.oneOf(Object.values(PriceBadgeTheme)),
+    size: PropTypes.oneOf(Object.values(PriseBadgeSize)),
+    subTitle: PropTypes.string,
     className: PropTypes.string,
     dataAttrs: PropTypes.shape({
         root: PropTypes.objectOf(PropTypes.string.isRequired).isRequired,

--- a/packages/ui-core/src/components/Badges/components/PriceBadge/__snapshots__/PriceBadge.test.tsx.snap
+++ b/packages/ui-core/src/components/Badges/components/PriceBadge/__snapshots__/PriceBadge.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<PriceBadge /> should render PriceBadge 1`] = `
 <div>
   <div
-    class="mfui-price-badge mfui-price-badge_theme_grey"
+    class="mfui-price-badge mfui-price-badge_theme_grey mfui-price-badge_size_small"
   >
     <div
       class="mfui-price-badge__icon-container"
@@ -12,11 +12,13 @@ exports[`<PriceBadge /> should render PriceBadge 1`] = `
         classname="mfui-price-badge__icon"
       />
     </div>
-    <span
+    <div
       class="mfui-price-badge__text"
     >
-      text
-    </span>
+      <div>
+        text
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/packages/ui-core/src/components/Badges/components/PriceBadge/doc/PriceBadge.example.mdx
+++ b/packages/ui-core/src/components/Badges/components/PriceBadge/doc/PriceBadge.example.mdx
@@ -10,7 +10,7 @@ import PriceBadge from '../PriceBadge';
 ## Размеры бейджа
 
 <Playground style={{ display: 'flex', gap: '20px', flexWrap: 'wrap', alignItems: 'center' }}>
-    <PriceBadge size="big">Большой бейдж</PriceBadge>
+    <PriceBadge size="big"><div style={{ width: "350px"}}>Большой бейдж</div></PriceBadge>
     <PriceBadge size="small" subTitle="с дополнительным текстом">Маленький бейдж (по умолчанию)</PriceBadge>
 </Playground>
 

--- a/packages/ui-core/src/components/Badges/components/PriceBadge/doc/PriceBadge.example.mdx
+++ b/packages/ui-core/src/components/Badges/components/PriceBadge/doc/PriceBadge.example.mdx
@@ -4,7 +4,21 @@ import PriceBadge from '../PriceBadge';
 ## Базовое использование
 
 <Playground>
-    <PriceBadge>Базовый бейдж</PriceBadge>   
+    <PriceBadge>Базовый бейдж</PriceBadge>
+</Playground>
+
+## Размеры бейджа
+
+<Playground style={{ display: 'flex', gap: '20px', flexWrap: 'wrap', alignItems: 'center' }}>
+    <PriceBadge size="big">Большой бейдж</PriceBadge>
+    <PriceBadge size="small" subTitle="с дополнительным текстом">Маленький бейдж (по умолчанию)</PriceBadge>
+</Playground>
+
+## Дополнительный текст
+
+<Playground style={{ display: 'flex', gap: '20px', flexWrap: 'wrap', alignItems: 'center' }}>
+    <PriceBadge size="big" subTitle="с дополнительным текстом">Большой бейдж</PriceBadge>
+    <PriceBadge subTitle="Дополнительный текст">Маленький бейдж доп. текст не выводит</PriceBadge>
 </Playground>
 
 ## Цветовые темы


### PR DESCRIPTION
<!-- Autogenerated checksum:2b3c9ee6628b04ef8cf0105476716cac5558db02_837cfaa487307c5c710bb3ce12ae8a9f1a128924 -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "4.15.0"
"version": "4.15.1"

ui-shared/package.json
"version": "4.15.1"
"version": "4.15.2"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
## [4.15.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@4.15.0...@megafon/ui-core@4.15.1) (2023-03-31)


### Bug Fixes

* **pricebadge:** new props size and subtitle ([5f40360](https://github.com/MegafonWebLab/megafon-ui/commit/5f40360509e703a8fab2f4936aa109a9b63bafcd))





## :memo: packages/ui-shared/CHANGELOG.md
## [4.15.2](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@4.15.1...@megafon/ui-shared@4.15.2) (2023-03-31)

**Note:** Version bump only for package @megafon/ui-shared





