### PR TITLE
fix(color): new danger color for text type button

### DIFF
--- a/packages/ui-core/src/components/Button/Button.less
+++ b/packages/ui-core/src/components/Button/Button.less
@@ -259,6 +259,39 @@
         }
     }
 
+    // type = text
+    // theme = danger
+
+    &_type_text&_theme_danger {
+        width: fit-content;
+
+        color: var(--fury);
+
+        background-color: transparent;
+
+        svg {
+            fill: var(--fury);
+        }
+    }
+
+    &_no-touch&_type_text&_theme_danger {
+        &:not(@{b}_loading):hover {
+            color: var(--warmRedC);
+
+            svg {
+                fill: var(--warmRedC);
+            }
+        }
+
+        &:not(@{b}_loading):active {
+            color: var(--buttonDown);
+
+            svg {
+                fill: var(--buttonDown);
+            }
+        }
+    }
+
     // type = primary
     // theme = green
 

--- a/packages/ui-core/src/components/Button/Button.tsx
+++ b/packages/ui-core/src/components/Button/Button.tsx
@@ -20,6 +20,7 @@ export const ButtonThemes = {
     PURPLE_SOFT: 'purple-soft',
     WHITE: 'white',
     BLACK: 'black',
+    DANGER: 'danger',
 } as const;
 
 type ButtonThemesType = typeof ButtonThemes[keyof typeof ButtonThemes];

--- a/packages/ui-core/src/components/Button/doc/Button.example.mdx
+++ b/packages/ui-core/src/components/Button/doc/Button.example.mdx
@@ -291,6 +291,29 @@ export const ref = createRef();
     </div>
 </Playground>
 
+### Красная
+
+<Playground style={{ ...blockStyle, backgroundColor: '#F5F5F5' }}>
+    <Button type="text" theme="danger">
+        active
+    </Button>
+    <Button type="text" theme="danger" disabled>
+        disabled
+    </Button>
+    <Button type="text" theme="danger" showLoader>
+        with loader
+    </Button>
+    <Button type="text" theme="danger" showArrow>
+        with arrow
+    </Button>
+    <Button type="text" theme="danger" icon={<Balance24 />}>
+        with icon
+    </Button>
+    <div>
+        <Button type="text" theme="danger" icon={<Balance24 />} />
+    </div>
+</Playground>
+
 ## Размеры
 Все размеры содержимого кнопки зависят от размера самой кнопки. 
 


### PR DESCRIPTION
<!-- Autogenerated checksum:2b3c9ee6628b04ef8cf0105476716cac5558db02_7f53fd8d369f664e678c8cb2a437ef4fa5c801fc -->


---
## Upcoming release changes
> New commits in branch will trigger this description update.

### Version updates:
```
ui-core/package.json
"version": "4.15.0"
"version": "4.15.1"

ui-shared/package.json
"version": "4.15.1"
"version": "4.15.2"
```
### Changelogs:
## :memo: packages/ui-core/CHANGELOG.md
## [4.15.1](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-core@4.15.0...@megafon/ui-core@4.15.1) (2023-03-31)


### Bug Fixes

* **color:** new danger color for text type button ([7f53fd8](https://github.com/MegafonWebLab/megafon-ui/commit/7f53fd8d369f664e678c8cb2a437ef4fa5c801fc))





## :memo: packages/ui-shared/CHANGELOG.md
## [4.15.2](https://github.com/MegafonWebLab/megafon-ui/compare/@megafon/ui-shared@4.15.1...@megafon/ui-shared@4.15.2) (2023-03-31)

**Note:** Version bump only for package @megafon/ui-shared





